### PR TITLE
feat: add ON DELETE CASCADE constraints for user-related entities

### DIFF
--- a/guardians/src/main/java/com/guardians/domain/badge/entity/UserBadge.java
+++ b/guardians/src/main/java/com/guardians/domain/badge/entity/UserBadge.java
@@ -20,7 +20,7 @@ public class UserBadge {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_user_badges_user"))
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/guardians/src/main/java/com/guardians/domain/board/entity/Answer.java
+++ b/guardians/src/main/java/com/guardians/domain/board/entity/Answer.java
@@ -24,7 +24,7 @@ public class Answer {
     private Question question; // 어떤 질문에 대한 답변인지
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_answers_user"))
     private User user; // 답변 작성자
 
     @Column(nullable = false, columnDefinition = "TEXT")

--- a/guardians/src/main/java/com/guardians/domain/board/entity/Board.java
+++ b/guardians/src/main/java/com/guardians/domain/board/entity/Board.java
@@ -21,7 +21,7 @@ public class Board {
 
     // 작성자
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_boards_user"))
     private User user;
 
     @Column(nullable = false)
@@ -29,7 +29,6 @@ public class Board {
 
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
-
 
     @Enumerated(EnumType.STRING)
     @Column(name = "board_type", nullable = false)

--- a/guardians/src/main/java/com/guardians/domain/board/entity/Comment.java
+++ b/guardians/src/main/java/com/guardians/domain/board/entity/Comment.java
@@ -26,7 +26,7 @@ public class Comment {
 
     // 댓글 작성자
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_comments_user"))
     private User user;
 
     @Column(columnDefinition = "TEXT", nullable = false)

--- a/guardians/src/main/java/com/guardians/domain/board/entity/Question.java
+++ b/guardians/src/main/java/com/guardians/domain/board/entity/Question.java
@@ -21,7 +21,7 @@ public class Question {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_questions_user"))
     private User user; // 질문 작성자
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/guardians/src/main/java/com/guardians/domain/user/entity/UserStats.java
+++ b/guardians/src/main/java/com/guardians/domain/user/entity/UserStats.java
@@ -20,7 +20,7 @@ public class UserStats {
 
     @OneToOne(fetch = FetchType.LAZY)
     @MapsId
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", foreignKey = @ForeignKey(name = "fk_user_stats_user"))
     private User user;
 
     private int score;

--- a/guardians/src/main/java/com/guardians/domain/wargame/entity/Bookmark.java
+++ b/guardians/src/main/java/com/guardians/domain/wargame/entity/Bookmark.java
@@ -18,7 +18,7 @@ public class Bookmark {
 
     @Id
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", foreignKey = @ForeignKey(name = "fk_bookmarks_user"))
     private User user;
 
     @Id

--- a/guardians/src/main/java/com/guardians/domain/wargame/entity/Review.java
+++ b/guardians/src/main/java/com/guardians/domain/wargame/entity/Review.java
@@ -21,7 +21,7 @@ public class Review {
 
     // 작성자
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_reviews_user"))
     private User user;
 
     // 관련 챌린지

--- a/guardians/src/main/java/com/guardians/domain/wargame/entity/SolvedWargame.java
+++ b/guardians/src/main/java/com/guardians/domain/wargame/entity/SolvedWargame.java
@@ -18,7 +18,7 @@ public class SolvedWargame {
 
     @Id
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", foreignKey = @ForeignKey(name = "fk_solved_wargames_user"))
     private User user;
 
     @Id

--- a/guardians/src/main/java/com/guardians/domain/wargame/entity/WargameLike.java
+++ b/guardians/src/main/java/com/guardians/domain/wargame/entity/WargameLike.java
@@ -22,7 +22,7 @@ public class WargameLike implements Serializable {
 
     // 좋아요 누른 유저
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_wargame_likes_user"))
     private User user;
 
     // 좋아요 대상 챌린지


### PR DESCRIPTION
## 📌 PR 제목
- `feat: add ON DELETE CASCADE constraints for user-related entities`

---

## ✨ 주요 변경사항
- 회원 탈퇴 시 연관된 데이터까지 자동 삭제되도록 외래키 제약 조건 설정
- 아래 테이블에 `ON DELETE CASCADE` 제약 조건 적용:
  - `user_badges`, `answers`, `boards`, `comments`, `questions`, `user_stats`,
    `bookmarks`, `reviews`, `solved_wargames`, `wargame_likes`
- 외래키 이름을 일관되게 정리 (`fk_xxxs_user` 형태)

---

## 🔍 상세 설명
- 기존에는 `users` 테이블 삭제 시 외래키 충돌로 인해 삭제가 불가능했음
- 해당 문제를 해결하기 위해 관련 테이블의 외래키에 `ON DELETE CASCADE` 제약 조건을 설정함
- 이제 `User` 엔티티 삭제 시 연관된 데이터(`user_badges` 등)도 자동으로 삭제됨
- JPA에서 `orphanRemoval`, `cascade`는 제거하고 DB 제약 조건으로 처리

---

## ✅ 확인 리스트
- [x] 회원 탈퇴 시 관련 데이터 자동 삭제 확인
- [x] 외래키 이름 중복/누락 없이 정리되었는지 검토
- [x] JPA 연관관계 설정에서 불필요한 cascade 옵션 제거
- [x] 불필요한 주석/코드 제거 완료

---

## 🧪 테스트 결과
- [x] 실제 유저 삭제 테스트 완료 (`DELETE FROM users WHERE id = ?`)
- [x] 연관 테이블(user_badges 등)에서 연쇄 삭제 확인
- [x] 재시작 후에도 외래키 제약 적용 정상 작동

---

## 📎 관련 이슈
Closes #이슈번호

---

## 💬 기타 공유사항
- 이후 추가되는 테이블도 user_id 외래키가 있을 경우 반드시 `ON DELETE CASCADE` 고려할 것
- 기존에 자동 생성된 foreign key 제약은 수동으로 모두 삭제 후 재등록함
