### PR TITLE
feat: update solved_count in user_stats after correct flag submission

### DIFF
--- a/guardians/src/main/java/com/guardians/controller/MypageController.java
+++ b/guardians/src/main/java/com/guardians/controller/MypageController.java
@@ -54,4 +54,13 @@ public class MypageController {
     public ResponseEntity<ResWrapper<?>> getRank(@PathVariable Long userId) {
         return ResponseEntity.ok(ResWrapper.resSuccess("내 랭킹 조회 성공", mypageService.getRank(userId)));
     }
+
+    @Operation(summary = "내 통계 정보 조회", description = "점수, 랭킹, 푼 문제 수 조회")
+    @GetMapping("/stats")
+    public ResponseEntity<ResWrapper<?>> getUserStats(@PathVariable Long userId) {
+        return ResponseEntity.ok(
+                ResWrapper.resSuccess("내 통계 정보 조회 성공", mypageService.getUserStats(userId))
+        );
+    }
+
 }

--- a/guardians/src/main/java/com/guardians/controller/UserController.java
+++ b/guardians/src/main/java/com/guardians/controller/UserController.java
@@ -222,7 +222,7 @@ public class UserController {
         return ResponseEntity.ok(ResWrapper.resSuccess("회원 탈퇴 완료", null));
     }
 
-    // UserId 반환
+    // UserId 정보 반환
     @GetMapping("/me")
     public ResponseEntity<ResWrapper<?>> getCurrentUser(HttpSession session) {
         try {

--- a/guardians/src/main/java/com/guardians/domain/user/repository/UserStatsRepository.java
+++ b/guardians/src/main/java/com/guardians/domain/user/repository/UserStatsRepository.java
@@ -2,10 +2,13 @@ package com.guardians.domain.user.repository;
 
 import com.guardians.domain.user.entity.UserStats;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.repository.query.Param;
 
 @Repository
 public interface UserStatsRepository extends JpaRepository<UserStats, Long> {
@@ -14,4 +17,10 @@ public interface UserStatsRepository extends JpaRepository<UserStats, Long> {
     // find all with user -> order by score desc
     @Query("SELECT us FROM UserStats us JOIN FETCH us.user ORDER BY us.score DESC")
     List<UserStats> findAllWithUserOrderByScoreDesc();
+    Optional<UserStats> findByUserId(Long userId);
+    @Modifying
+
+    @Query("UPDATE UserStats us SET us.totalSolved = :count WHERE us.user.id = :userId")
+    void updateSolvedCount(@Param("userId") Long userId, @Param("count") Long count);
+
 }

--- a/guardians/src/main/java/com/guardians/domain/wargame/repository/SolvedWargameRepository.java
+++ b/guardians/src/main/java/com/guardians/domain/wargame/repository/SolvedWargameRepository.java
@@ -5,6 +5,7 @@ import com.guardians.domain.wargame.entity.SolvedWargame;
 import com.guardians.domain.wargame.entity.SolvedWargameId;
 import com.guardians.domain.wargame.entity.Wargame;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -17,4 +18,9 @@ public interface SolvedWargameRepository extends JpaRepository<SolvedWargame, So
     List<SolvedWargame> findByWargame(Wargame wargame);
     List<SolvedWargame> findByUser_Id(Long userId);
     boolean existsByUser_IdAndWargame_Id(Long userId, Long wargameId);
+    Long countByUser(User user);
+
+    @Query("SELECT sw.user.id, COUNT(sw) FROM SolvedWargame sw GROUP BY sw.user.id")
+    List<Object[]> countSolvedCountByUser();
+
 }

--- a/guardians/src/main/java/com/guardians/dto/mypage/res/ResUserStatsDto.java
+++ b/guardians/src/main/java/com/guardians/dto/mypage/res/ResUserStatsDto.java
@@ -1,0 +1,13 @@
+package com.guardians.dto.mypage.res;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResUserStatsDto {
+    private int score;
+    private int rank;
+    private int solvedCount;
+}

--- a/guardians/src/main/java/com/guardians/service/mypage/MypageService.java
+++ b/guardians/src/main/java/com/guardians/service/mypage/MypageService.java
@@ -1,6 +1,7 @@
 package com.guardians.service.mypage;
 
 import com.guardians.dto.mypage.res.*;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -12,7 +13,7 @@ public interface MypageService {
     ResPostDto getPosts(Long userId);
     ResReviewDto getReviews(Long userId);
     ResRankDto getRank(Long userId);
-
-    // ✅ 전체 랭킹 조회 추가
     List<ResRankDto> getAllRanks();
+    ResUserStatsDto getUserStats(Long userId);
+
 }


### PR DESCRIPTION
## 📌 PR 제목
- feat: update solved_count in user_stats after correct flag submission

---

## ✨ 주요 변경사항
- 사용자가 정답 제출 시 `solved_wargames` 테이블에 기록
- 문제 풀이 성공 시 `user_stats.solved_count`를 실시간으로 업데이트

---

## 🔍 상세 설명
- 기존에는 solved 기록만 저장했으나, 실시간 랭킹 반영을 위해 통계 갱신 로직 추가
- `SolvedWargameRepository.countByUser(User)`로 푼 문제 수 계산
- `UserStatsRepository.updateSolvedCount(userId, count)`로 해당 유저의 통계 반영

---

## ✅ 확인 리스트
- [x] 정답 제출 시 solved_wargames 저장 확인
- [x] 중복 풀이 방지 처리 확인
- [x] user_stats의 solved_count 반영 확인
- [ ] 예외 처리 (로그인 안 된 경우 등) 정상 동작

---

## 🧪 테스트 결과
- [x] Postman으로 flag 제출 API 호출 테스트 완료
- [x] DB에서 solved_wargames / user_stats 업데이트 확인
- [x] 프론트에서 통계 정상 반영 확인

---

## 📎 관련 이슈

---

## 💬 기타 공유사항
- 이후 `score` 반영 로직도 함께 붙일 예정
- 점수에 따라 추가 뱃지 기능 고려 중
