### PR TITLE
feat: add list response wrapper with count for consistent list API st…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 **/build/
 .gradle/
 **/.gradle/*
-**/build/
+**/build/**
 
 # Spring Native 관련
 spring-backend/wrapper/

--- a/guardians/src/main/java/com/guardians/controller/QnaController.java
+++ b/guardians/src/main/java/com/guardians/controller/QnaController.java
@@ -36,6 +36,13 @@ public class QnaController {
         return ResponseEntity.ok(ResWrapper.resSuccess("질문 등록 완료", null));
     }
 
+    // 모든 질문 목록 조회
+    @GetMapping("/questions")
+    public ResponseEntity<ResWrapper<?>> getAllQuestions() {
+        List<ResQuestionListDto> response = questionService.getQuestionList();
+        return ResponseEntity.ok(ResWrapper.resSuccess("전체 질문 목록 조회 성공", response));
+    }
+
     // 특정 워게임 질문 목록 조회
     @GetMapping("/wargames/{wargameId}/questions")
     public ResponseEntity<ResWrapper<?>> getQuestionsByWargame(@PathVariable Long wargameId) {
@@ -83,7 +90,7 @@ public class QnaController {
     @GetMapping("/answers/{questionId}")
     public ResponseEntity<ResWrapper<?>> getAnswerListByQuestion(@PathVariable Long questionId) {
         List<ResAnswerListDto> response = answerService.getAnswerListByQuestion(questionId);
-        return ResponseEntity.ok(ResWrapper.resSuccess("답변 목록 조회 성공", response));
+        return ResponseEntity.ok(ResWrapper.resList("답변 목록 조회 성공", response, response.size()));
     }
 
     // 답변 수정

--- a/guardians/src/main/java/com/guardians/domain/board/repository/AnswerRepository.java
+++ b/guardians/src/main/java/com/guardians/domain/board/repository/AnswerRepository.java
@@ -12,6 +12,7 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
     @Query("SELECT a FROM Answer a JOIN FETCH a.user WHERE a.id = :id")
     Optional<Answer> findByIdWithUser(@Param("id") Long id);
+    int countByQuestionId(Long questionId);
 
     List<Answer> findAllByQuestionId(Long questionId);
 }

--- a/guardians/src/main/java/com/guardians/dto/common/ListResult.java
+++ b/guardians/src/main/java/com/guardians/dto/common/ListResult.java
@@ -8,16 +8,18 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Schema(description = "성공 응답 데이터 구조")
-public class SuccessResult {
+@Schema(description = "리스트 응답 데이터 구조")
+public class ListResult {
 
     @Schema(description = "HTTP 상태 코드", example = "200")
     private int status;
 
-    @Schema(description = "응답 데이터")
+    @Schema(description = "리스트 데이터")
     private Object data;
 
-    @Schema(description = "성공 메시지", example = "요청 성공")
+    @Schema(description = "응답 메시지")
     private String message;
 
+    @Schema(description = "총 데이터 개수")
+    private int count;
 }

--- a/guardians/src/main/java/com/guardians/dto/common/ResWrapper.java
+++ b/guardians/src/main/java/com/guardians/dto/common/ResWrapper.java
@@ -25,6 +25,17 @@ public class ResWrapper<T> {
                 .build();
     }
 
+    public static ResWrapper<ListResult> resList(String message, Object list, int count) {
+        return ResWrapper.<ListResult>builder()
+                .result(ListResult.builder()
+                        .status(200)
+                        .message(message)
+                        .data(list)
+                        .count(count)
+                        .build())
+                .build();
+    }
+
     public static ResWrapper<ErrorResult> resException(Exception e) {
         return ResWrapper.<ErrorResult>builder()
                 .result(ErrorResult.builder()

--- a/guardians/src/main/java/com/guardians/service/answer/AnswerService.java
+++ b/guardians/src/main/java/com/guardians/service/answer/AnswerService.java
@@ -14,9 +14,6 @@ public interface AnswerService {
     // 답변 등록
     ResCreateAnswerDto createAnswer(Long userId, ReqCreateAnswerDto dto);
 
-    // 답변 단건 상세 조회
-    ResAnswerDetailDto getAnswerDetail(Long answerId);
-
     // 특정 질문에 대한 답변 목록 조회
     List<ResAnswerListDto> getAnswerListByQuestion(Long questionId);
 

--- a/guardians/src/main/java/com/guardians/service/answer/AnswerServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/answer/AnswerServiceImpl.java
@@ -63,22 +63,6 @@ public class AnswerServiceImpl implements AnswerService {
     }
 
     @Override
-    public ResAnswerDetailDto getAnswerDetail(Long answerId) {
-        // 단건 답변 조회
-        Answer answer = answerRepository.findByIdWithUser(answerId)
-                .orElseThrow(() -> new CustomException(ErrorCode.ANSWER_NOT_FOUND));
-
-        // 결과 반환
-        return ResAnswerDetailDto.builder()
-                .id(answer.getId())
-                .content(answer.getContent())
-                .username(answer.getUser().getUsername())
-                .createdAt(answer.getCreatedAt())
-                .updatedAt(answer.getUpdatedAt())
-                .build();
-    }
-
-    @Override
     public List<ResAnswerListDto> getAnswerListByQuestion(Long questionId) {
         // 특정 질문에 대한 답변 목록 조회
         List<Answer> answers = answerRepository.findAllByQuestionId(questionId);


### PR DESCRIPTION
## 📌 PR 제목
- `feat: add list response wrapper with count metadata`

---

## ✨ 주요 변경사항
- 리스트 응답을 위한 공통 wrapper (`ListResult`) 추가
- `ResWrapper.resList()` 오버로딩 메서드 도입
- 기존 단일 응답과 분리하여 리스트 전용 구조 지원

---

## 🔍 상세 설명
- 여러 API에서 공통적으로 리스트 + count 반환이 필요해짐
- 기존 `SuccessResult`에 count 추가 시 전체 응답 구조 변경 부담 → 별도 wrapper 분리
- Swagger 문서와 응답 일관성 유지 목적
- 답변 목록, 질문 목록 등

---

## ✅ 확인 리스트
- [x] 기능 정상 동작 확인
- [x] API 응답 형식 일관성 확인
- [x] 불필요한 로그/주석 제거
- [ ] 프론트와 연동 테스트
- [ ] Swagger UI 응답 확인

---

## 🧪 테스트 결과
- Postman으로 `/api/qna/answers/{questionId}` 호출 → `data + count` 정상 확인
- 응답 포맷 기존 구조와 충돌 없음

---

## 📎 관련 이슈

---

## 💬 기타 공유사항
- 다음 적용 대상: `/api/qna/questions`, 게시판 목록 API 등
- 추후 `page`, `totalPages` 등도 `ListResult`에 확장 가능
