### PR TITLE
feat : add PATCH method in CORS

### DIFF
--- a/guardians/src/main/java/com/guardians/config/CorsConfig.java
+++ b/guardians/src/main/java/com/guardians/config/CorsConfig.java
@@ -16,7 +16,7 @@ public class CorsConfig {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
         config.setAllowedOrigins(List.of("http://localhost:5173"));
-        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS")); // 허용할 HTTP 메서드
+        config.setAllowedMethods(List.of("PATCH", "GET", "POST", "PUT", "DELETE", "OPTIONS")); // 허용할 HTTP 메서드
         config.setAllowedHeaders(List.of("*")); // 모든 헤더 허용
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/guardians/src/main/java/com/guardians/service/user/UserServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/user/UserServiceImpl.java
@@ -163,6 +163,7 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 
+    @Transactional
     @Override
     public void updateProfileImageUrl(Long userId, String imageUrl) {
         User user = userRepository.findById(userId)


### PR DESCRIPTION
## 📌 PR 제목  
- `feat: CORS에 PATCH 메서드 허용 추가`

---

## ✨ 주요 변경사항  
- CORS 설정에 PATCH 메서드 허용 추가 (`allowedMethods`에 `"PATCH"` 추가)

---

## 🔍 상세 설명  
- 마이페이지에서 닉네임/비밀번호 수정 시 PATCH 요청 발생  
- 기존 CORS 설정에서 PATCH가 빠져있어 `403 Forbidden` 에러 발생  
- 백엔드 CORS 설정에 PATCH 메서드를 추가하여 문제 해결

---

## ✅ 확인 리스트  
- [x] PATCH 요청 시 CORS 오류 발생하지 않음 확인  
- [x] Swagger 테스트 및 프론트 연동 확인  
- [x] 기타 CORS 메서드(GET, POST 등)에 영향 없음 확인

---

## 🧪 테스트 결과  
- [x] 로컬에서 프론트 PATCH 요청 정상 응답 확인  
- [x] Swagger UI에서 PATCH 테스트 성공  
- [ ] 운영 환경 테스트 (❌ — 개발 환경 기준)

---

## 📎 관련 이슈  

---

## 💬 기타 공유사항  
- 추후 메서드 외에도 Origin, Headers 설정도 점검 필요  
- OPTIONS preflight 요청 캐시 시간 설정 고려 가능
