### PR TITLE
feat: create UserStats with default score 1000 when user is created

### DIFF
--- a/guardians/src/main/java/com/guardians/domain/user/entity/User.java
+++ b/guardians/src/main/java/com/guardians/domain/user/entity/User.java
@@ -46,6 +46,14 @@ public class User {
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
+    private UserStats userStats;
+
+    public void setUserStats(UserStats userStats) {
+        this.userStats = userStats;
+    }
+
+
     public static User create(String username, String email, String password, String role, String profileImageUrl) {
         User user = new User();
         user.username = username;
@@ -53,8 +61,20 @@ public class User {
         user.password = password;
         user.role = role;
         user.profileImageUrl = profileImageUrl;
+
+        UserStats stats = UserStats.builder()
+                .user(user)
+                .score(1000)
+                .totalSolved(0)
+                .lastSolvedAt(null)
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        user.setUserStats(stats);
+
         return user;
     }
+
 
     public void updateLastLoginAt() {
         this.lastLoginAt = LocalDateTime.now();

--- a/guardians/src/main/java/com/guardians/domain/user/entity/UserStats.java
+++ b/guardians/src/main/java/com/guardians/domain/user/entity/UserStats.java
@@ -23,7 +23,7 @@ public class UserStats {
     @JoinColumn(name = "user_id", foreignKey = @ForeignKey(name = "fk_user_stats_user"))
     private User user;
 
-    private int score;
+    private int score = 1000;
 
     @Column(name = "total_solved")
     private int totalSolved;

--- a/guardians/src/main/java/com/guardians/service/user/UserServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/user/UserServiceImpl.java
@@ -2,7 +2,9 @@ package com.guardians.service.user;
 
 import com.guardians.config.AwsS3Properties;
 import com.guardians.domain.user.entity.User;
+import com.guardians.domain.user.entity.UserStats;
 import com.guardians.domain.user.repository.UserRepository;
+import com.guardians.domain.user.repository.UserStatsRepository;
 import com.guardians.dto.user.req.ReqChangePasswordDto;
 import com.guardians.dto.user.req.ReqCreateUserDto;
 import com.guardians.dto.user.req.ReqLoginDto;
@@ -18,6 +20,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -27,6 +31,7 @@ public class UserServiceImpl implements UserService {
     private final PasswordEncoder passwordEncoder;
     private final EmailVerificationService emailVerificationService;
     private final AwsS3Properties awsS3Properties;
+    private final UserStatsRepository userStatsRepository;
 
     // 중복 검사
     private void validateDuplicate(ReqCreateUserDto dto) {


### PR DESCRIPTION
## 📌 PR 제목
- feat: create UserStats with default score 1000 when user is created

---

## ✨ 주요 변경사항
- 회원가입(createUser) 시 UserStats 엔티티도 자동 생성되도록 로직 수정
- UserStats 기본 점수(score)를 1000으로 설정
- users → user_stats 외래키 CASCADE 재설정으로 삭제 오류 해결

---

## 🔍 상세 설명
- 기존에는 유저 등록 시 user_stats가 따로 생성되어야 했기 때문에 연동되지 않았음
- 이를 자동화하여 유저 생성 시 통계 정보도 함께 생성되도록 처리
- 외래키 충돌로 삭제 불가하던 문제를 해결하기 위해 fk 제약조건을 DROP 후 ON DELETE CASCADE로 재설정

---

## ✅ 확인 리스트
- [x] 회원가입 시 UserStats 레코드 생성 확인
- [x] score 값이 1000으로 정상 등록됨 확인
- [x] 회원 삭제 시 user_stats도 함께 삭제되는지 확인
- [x] 예외 처리 및 기존 기능 영향 여부 확인

---

## 🧪 테스트 결과
- [x] Postman으로 회원가입 → DB에 user_stats 연동 확인
- [x] 직접 삭제 테스트로 CASCADE 정상 작동 확인
- [x] 잘못된 입력에 대한 예외 처리 확인

---

## 📎 관련 이슈
- 없음

---

## 💬 기타 공유사항
- 회원 생성/삭제 관련 테스트 코드 추가 예정
- 추후 랭킹 API에도 초기 점수 반영 여부 확인 필요
