### PR TITLE
refactor: update entity relations for user deletion handling

### DIFF
--- a/guardians/src/main/java/com/guardians/domain/board/entity/Board.java
+++ b/guardians/src/main/java/com/guardians/domain/board/entity/Board.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "boards")
@@ -47,6 +49,12 @@ public class Board {
 
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<BoardLike> boardLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
 
     @PrePersist
     protected void onCreate() {

--- a/guardians/src/main/java/com/guardians/domain/board/entity/Comment.java
+++ b/guardians/src/main/java/com/guardians/domain/board/entity/Comment.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "comments")
@@ -21,8 +23,8 @@ public class Comment {
 
     // 댓글이 달린 게시글
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id", nullable = false)
-    private Board post;
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
 
     // 댓글 작성자
     @ManyToOne(fetch = FetchType.LAZY)

--- a/guardians/src/main/java/com/guardians/domain/board/entity/Question.java
+++ b/guardians/src/main/java/com/guardians/domain/board/entity/Question.java
@@ -6,6 +6,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "questions")
@@ -33,6 +35,9 @@ public class Question {
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
+
+    @OneToMany(mappedBy = "question", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Answer> answers = new ArrayList<>();
 
     @Column(name = "created_at")
     private LocalDateTime createdAt;

--- a/guardians/src/main/java/com/guardians/domain/board/repository/CommentRepository.java
+++ b/guardians/src/main/java/com/guardians/domain/board/repository/CommentRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     //댓글 목록 조회용
-    @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.post.id = :boardId")
+    @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.board.id = :boardId")
     List<Comment> findByBoardIdWithUser(@Param("boardId") Long boardId);
     //특정댓글 수정, 삭제용
     @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.id = :commentId")

--- a/guardians/src/main/java/com/guardians/domain/user/entity/User.java
+++ b/guardians/src/main/java/com/guardians/domain/user/entity/User.java
@@ -1,5 +1,8 @@
 package com.guardians.domain.user.entity;
 
+import com.guardians.domain.badge.entity.UserBadge;
+import com.guardians.domain.board.entity.*;
+import com.guardians.domain.wargame.entity.*;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -9,6 +12,8 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "users")
@@ -34,7 +39,7 @@ public class User {
     private String password;
 
     @Column(nullable = false)
-    private String role; // USER, ADMIN
+    private String role;
 
     private LocalDateTime lastLoginAt;
 
@@ -46,13 +51,38 @@ public class User {
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private UserStats userStats;
 
-    public void setUserStats(UserStats userStats) {
-        this.userStats = userStats;
-    }
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Answer> answers = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Board> boards = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Question> questions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Review> reviews = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<SolvedWargame> solvedWargames = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<UserBadge> userBadges = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Bookmark> bookmarks = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<BoardLike> boardLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<WargameLike> wargameLikes = new ArrayList<>();
 
     public static User create(String username, String email, String password, String role, String profileImageUrl) {
         User user = new User();
@@ -70,11 +100,14 @@ public class User {
                 .updatedAt(LocalDateTime.now())
                 .build();
 
-        user.setUserStats(stats);
+        user.userStats = stats;
 
         return user;
     }
 
+    public void setUserStats(UserStats userStats) {
+        this.userStats = userStats;
+    }
 
     public void updateLastLoginAt() {
         this.lastLoginAt = LocalDateTime.now();
@@ -87,8 +120,8 @@ public class User {
     public void updateUsername(String username) {
         this.username = username;
     }
+
     public void updatePassword(String newPassword) {
         this.password = newPassword;
     }
-
 }

--- a/guardians/src/main/java/com/guardians/domain/user/entity/UserStats.java
+++ b/guardians/src/main/java/com/guardians/domain/user/entity/UserStats.java
@@ -23,7 +23,7 @@ public class UserStats {
     @JoinColumn(name = "user_id", foreignKey = @ForeignKey(name = "fk_user_stats_user"))
     private User user;
 
-    private int score = 1000;
+    private int score;
 
     @Column(name = "total_solved")
     private int totalSolved;

--- a/guardians/src/main/java/com/guardians/domain/wargame/entity/Wargame.java
+++ b/guardians/src/main/java/com/guardians/domain/wargame/entity/Wargame.java
@@ -1,10 +1,13 @@
 package com.guardians.domain.wargame.entity;
 
+import com.guardians.domain.board.entity.Question;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.nio.file.FileStore;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "wargames")
@@ -45,5 +48,20 @@ public class Wargame {
 
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    @OneToOne(mappedBy = "wargame", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private WargameFlag wargameFlag;
+
+    @OneToMany(mappedBy = "wargame", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<WargameLike> wargameLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "wargame", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<SolvedWargame> solvedWargames = new ArrayList<>();
+
+    @OneToMany(mappedBy = "wargame", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Review> reviews = new ArrayList<>();
+
+    @OneToMany(mappedBy = "wargame", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Question> questions = new ArrayList<>();
 
 }

--- a/guardians/src/main/java/com/guardians/service/board/CommentServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/board/CommentServiceImpl.java
@@ -37,7 +37,7 @@ public class CommentServiceImpl implements CommentService {
 
         Comment comment = Comment.builder()
                 .user(user)
-                .post(board)
+                .board(board)
                 .content(dto.getContent())
                 .build();
 

--- a/guardians/src/main/java/com/guardians/service/user/UserServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/user/UserServiceImpl.java
@@ -51,9 +51,17 @@ public class UserServiceImpl implements UserService {
 
         String encodedPw = passwordEncoder.encode(dto.getPassword());
 
-        User user = User.create(dto.getUsername(), dto.getEmail(), encodedPw, "USER", awsS3Properties.getDefaultProfileUrl());
+        User user = User.create(
+                dto.getUsername(),
+                dto.getEmail(),
+                encodedPw,
+                "USER",
+                awsS3Properties.getDefaultProfileUrl()
+        );
 
-        User saved = userRepository.save(user);
+        // 여기서 userStats도 내부에서 생성되어 연결된 상태
+        User saved = userRepository.save(user); // 🚨 userStats도 cascade로 같이 저장됨
+
         return ResCreateUserDto.fromEntity(saved);
     }
 


### PR DESCRIPTION
## 📌 PR 제목
- refactor: update entity relations for user deletion handling

---

## ✨ 주요 변경사항
- User 엔티티와 연관된 Board, Comment, Answer 등의 관계 설정 수정
- 게시글(Board) 및 댓글(Comment) 삭제 시 연관 엔티티 제거 처리 보장
- JPA cascade 설정 및 orphanRemoval 적용

---

## 🔍 상세 설명
- 유저 삭제 또는 게시글 삭제 시 연관된 댓글/답변 등 자식 엔티티가 삭제되지 않아 FK 제약 조건 위반 발생
- 이를 해결하기 위해 `@OneToMany` 관계에 `cascade = REMOVE`와 `orphanRemoval = true` 옵션 추가
- JPA 환경에서 객체 삭제 시 연관된 엔티티들도 자동으로 삭제되도록 처리

---

## ✅ 확인 리스트
- [x] 기능 정상 동작 확인
- [x] 에러 핸들링 및 예외 처리 확인
- [x] API 응답 형식 일관성 확인
- [x] 불필요한 로그/주석 제거

---

## 🧪 테스트 결과
- [x] Postman/Swagger로 API 테스트
- [x] 프론트에서 연동 확인
- [ ] 유닛/통합 테스트 포함 (있다면)

---

## 📎 관련 이슈
Closes #36

---

## 💬 기타 공유사항
- SQL 단에서 직접 DELETE 쿼리를 실행할 경우 여전히 FK 제약 위반 발생할 수 있음
- 필요 시 DB에서도 `ON DELETE CASCADE` 설정 고려 가능
- 향후 유저 탈퇴 기능과 함께 연동 예정
