### PR TITLE
feat: handle wargame pod recreation with deletion wait and status check

### DIFF
--- a/guardians/build.gradle
+++ b/guardians/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     implementation 'software.amazon.awssdk:auth:2.25.15'
 
     // k8s
-    implementation "io.fabric8:kubernetes-client:6.10.0"
+    implementation "io.fabric8:kubernetes-client:6.9.2"
 
     // Vault
     implementation("org.springframework.cloud:spring-cloud-starter-vault-config")

--- a/guardians/src/main/java/com/guardians/controller/WargameController.java
+++ b/guardians/src/main/java/com/guardians/controller/WargameController.java
@@ -133,7 +133,8 @@ public class WargameController {
         String namespace = "default";
 
         kubernetesPodService.createWargamePod(podName, wargameId, userId, namespace);
-        String url = "http://" + podName + ".example.com";
+
+        String url = "http://wargames.bee-guardians.com/wargame/" + wargameId + "/" + userId + "/";
 
         return ResponseEntity.ok(
                 ResWrapper.resSuccess("워게임 인스턴스 시작됨", Map.of(
@@ -159,9 +160,18 @@ public class WargameController {
 
         boolean deleted = kubernetesPodService.deleteWargamePod(podName, namespace);
         if (deleted) {
-            return ResponseEntity.ok(ResWrapper.resSuccess("워게임 인스턴스 종료됨", null));
+            return ResponseEntity.ok(
+                    ResWrapper.resSuccess("워게임 인스턴스 종료됨", Map.of(
+                            "podName", podName,
+                            "url", "http://wargames.bee-guardians.com/wargame/" + wargameId + "/" + userId + "/"
+                    ))
+            );
         } else {
-            return ResponseEntity.ok(ResWrapper.resSuccess("종료할 워게임 인스턴스를 찾을 수 없음", null));
+            return ResponseEntity.ok(
+                    ResWrapper.resSuccess("종료할 워게임 인스턴스를 찾을 수 없음", Map.of(
+                            "podName", podName
+                    ))
+            );
         }
     }
 


### PR DESCRIPTION
## 📌 PR 제목
- fix: improve pod creation flow with retry and deletion wait logic

---

## ✨ 주요 변경사항
- 기존 인스턴스가 존재할 경우 삭제 후 대기 로직 추가 (최대 10초, 초당 1회 체크)
- Ingress/Service/Pod 삭제 완료 여부 확인 후 새 인스턴스 생성
- 인스턴스 생성 실패 시 RuntimeException으로 명확한 에러 응답 제공
- 인그레스 등록 후 3초간 대기하여 접속 가능성 확보

---

## 🔍 상세 설명
- 기존에 `start → stop → start` 시 바로 재시작하면, 이전 인스턴스가 완전히 삭제되지 않아 409 Conflict 발생함
- 이를 해결하기 위해 Pod/Service/Ingress 삭제 완료 여부를 polling 방식으로 1초 간격으로 10초간 체크
- 모두 삭제되었을 경우에만 새 인스턴스를 생성하도록 변경
- UX 상 인그레스 등록 후 클라이언트가 접속 시도 전에 최소한 준비 시간 확보를 위해 3초 딜레이 추가

---

## ✅ 확인 리스트
- [x] 기능 정상 동작 확인
- [x] 에러 핸들링 및 예외 처리 확인
- [x] API 응답 형식 일관성 확인
- [x] 불필요한 로그/주석 제거

---

## 🧪 테스트 결과
- [x] Postman으로 `/api/wargames/{id}/start`, `/stop` 호출 테스트
- [x] 프론트에서 연동 테스트 완료 (`접속 URL` 노출 확인)
- [ ] 유닛 테스트는 별도로 작성 예정

---

## 📎 관련 이슈

---

## 💬 기타 공유사항
- 추후 파드 상태 조회 API (`GET /status`) 추가 예정
- 프론트엔드에서는 로딩 UI 및 실패 시 안내 문구도 함께 적용됨
