### PR TITLE
feat: include 'liked' status in board detail response

### DIFF
--- a/guardians/src/main/java/com/guardians/controller/BoardController.java
+++ b/guardians/src/main/java/com/guardians/controller/BoardController.java
@@ -53,10 +53,14 @@ public class BoardController {
     // 게시글 상세 조회
     @Operation(summary = "게시글 상세 조회", description = "특정 게시글 ID로 상세 정보를 조회합니다.")
     @GetMapping("/{boardId}")
-    public ResponseEntity<ResWrapper<?>> getBoardDetail(@PathVariable Long boardId) {
-        ResBoardDetailDto result = boardService.getBoardDetail(boardId);
+    public ResponseEntity<ResWrapper<?>> getBoardDetail(@PathVariable Long boardId, HttpSession session) {
+        Long userId = (Long) session.getAttribute("userId");
+
+        ResBoardDetailDto result = boardService.getBoardDetail(boardId, userId);
         return ResponseEntity.ok(ResWrapper.resSuccess("게시글 상세 조회 성공", result));
     }
+
+
     // 게시글 수정
     @Operation(summary = "게시글 수정", description = "게시글 작성자만 게시글을 수정할 수 있습니다.")
     @PatchMapping("/{boardId}")

--- a/guardians/src/main/java/com/guardians/domain/board/repository/BoardLikeRepository.java
+++ b/guardians/src/main/java/com/guardians/domain/board/repository/BoardLikeRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface BoardLikeRepository extends JpaRepository<BoardLike, Long> {
     Optional<BoardLike> findByUserIdAndBoardId(Long userId, Long boardId);
     void deleteByUserIdAndBoardId(Long userId, Long boardId);
+    boolean existsByBoardIdAndUserId(Long boardId, Long userId);
 }

--- a/guardians/src/main/java/com/guardians/dto/board/req/ReqUpdateBoardDto.java
+++ b/guardians/src/main/java/com/guardians/dto/board/req/ReqUpdateBoardDto.java
@@ -1,6 +1,5 @@
 package com.guardians.dto.board.req;
 
-import com.guardians.domain.board.entity.BoardType;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,6 +8,4 @@ import lombok.Setter;
 public class ReqUpdateBoardDto {
     private String title;
     private String content;
-    private BoardType boardType;
-
 }

--- a/guardians/src/main/java/com/guardians/dto/board/res/ResBoardDetailDto.java
+++ b/guardians/src/main/java/com/guardians/dto/board/res/ResBoardDetailDto.java
@@ -16,5 +16,8 @@ public class ResBoardDetailDto {
     private int likeCount;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private String boardType;
     private Long userId;
+    private boolean liked;
+
 }

--- a/guardians/src/main/java/com/guardians/dto/board/res/ResUpdateBoardDto.java
+++ b/guardians/src/main/java/com/guardians/dto/board/res/ResUpdateBoardDto.java
@@ -2,6 +2,7 @@ package com.guardians.dto.board.res;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -14,4 +15,5 @@ public class ResUpdateBoardDto {
     private String content;
     private String username;
     private LocalDateTime updatedAt;
+    private String boardType;
 }

--- a/guardians/src/main/java/com/guardians/service/board/BoardService.java
+++ b/guardians/src/main/java/com/guardians/service/board/BoardService.java
@@ -15,7 +15,7 @@ public interface BoardService {
 
     List<ResBoardListDto> getBoardList(BoardType boardType);
 
-    ResBoardDetailDto getBoardDetail(Long boardId);
+    ResBoardDetailDto getBoardDetail(Long boardId, Long userId);
 
     ResUpdateBoardDto updateBoard(Long userId, Long boardId, ReqUpdateBoardDto dto);
 

--- a/guardians/src/main/java/com/guardians/service/board/BoardServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/board/BoardServiceImpl.java
@@ -70,11 +70,13 @@ public class BoardServiceImpl implements BoardService {
                 .createdAt(board.getCreatedAt())
                 .build()).collect(Collectors.toList());
     }
-
+    @Transactional
     @Override
-    public ResBoardDetailDto getBoardDetail(Long boardId) {
+    public ResBoardDetailDto getBoardDetail(Long boardId,Long userId) {
         Board board = boardRepository.findByIdWithUser(boardId)
                 .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
+
+        boolean liked = boardLikeRepository.existsByBoardIdAndUserId(boardId, userId);
 
         return ResBoardDetailDto.builder()
                 .boardId(board.getId())
@@ -86,9 +88,11 @@ public class BoardServiceImpl implements BoardService {
                 .createdAt(board.getCreatedAt())
                 .updatedAt(board.getUpdatedAt())
                 .userId(board.getUser().getId())
+                .boardType(board.getBoardType().name())
+                .liked(liked)
                 .build();
     }
-
+    @Transactional
     @Override
     public ResUpdateBoardDto updateBoard(Long userId, Long boardId, ReqUpdateBoardDto dto) {
         Board board = boardRepository.findByIdWithUser(boardId)
@@ -100,7 +104,6 @@ public class BoardServiceImpl implements BoardService {
 
         board.setTitle(dto.getTitle());
         board.setContent(dto.getContent());
-        board.setBoardType(dto.getBoardType());
         board.setUpdatedAt(LocalDateTime.now());
 
         Board updatedBoard = boardRepository.save(board);
@@ -111,6 +114,7 @@ public class BoardServiceImpl implements BoardService {
                 .content(updatedBoard.getContent())
                 .username(updatedBoard.getUser().getUsername())
                 .updatedAt(updatedBoard.getUpdatedAt())
+                .boardType(board.getBoardType().name())
                 .build();
     }
 


### PR DESCRIPTION
## 📌 PR 제목
- feat: add liked status to board detail response

---

## ✨ 주요 변경사항
- 게시글 상세 응답 DTO에 `liked` 필드 추가
- 현재 사용자의 좋아요 여부를 `BoardLikeRepository`를 통해 조회
- `getBoardDetail(Long boardId)` → `getBoardDetail(Long boardId, Long userId)` 시그니처 변경
- 컨트롤러에서 세션을 통해 userId 전달
- BoardService 인터페이스 수정

---

## 🔍 상세 설명
- 게시글 상세 페이지에서 "좋아요 버튼 눌림 상태"를 UI에 반영하기 위해 개선
- 현재 사용자가 해당 게시글에 좋아요를 눌렀는지 여부를 API 응답에 포함
- 프론트에서 게시글 진입 시 좋아요 상태가 항상 초기화되던 문제 해결

---

## ✅ 확인 리스트
- [x] 기능 정상 동작 확인
- [x] 에러 핸들링 및 예외 처리 확인
- [x] API 응답 형식 일관성 확인
- [x] 불필요한 로그/주석 제거

---

## 🧪 테스트 결과
- [x] Postman으로 board detail API 테스트 완료
- [x] 프론트 연동 확인 (liked 상태 UI 반영 확인)
- [ ] 유닛 테스트는 별도 작성 예정

---

## 📎 관련 이슈

---

## 💬 기타 공유사항
- 추후 좋아요 토글 기능의 트랜잭션 보장 및 optimistic lock 적용 고려
- 댓글, 북마크 등 다른 사용자 기반 상태도 유사하게 확장 가능
