### PR TITLE
feat: implement keyword search and validation for board API

### DIFF
--- a/guardians/src/main/java/com/guardians/domain/board/repository/BoardRepository.java
+++ b/guardians/src/main/java/com/guardians/domain/board/repository/BoardRepository.java
@@ -2,6 +2,7 @@ package com.guardians.domain.board.repository;
 
 import com.guardians.domain.board.entity.Board;
 import com.guardians.domain.board.entity.BoardType;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,6 +20,13 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     Optional<Board> findByIdWithUser(@Param("id") Long id);
 
     List<Board> findAllByUserId(Long userId); // 추가
+
+    @EntityGraph(attributePaths = {"user"})
+    @Query("SELECT b FROM Board b WHERE b.boardType = :boardType AND " +
+            "(LOWER(b.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(b.content) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+    List<Board> findByBoardTypeAndKeyword(@Param("boardType") BoardType boardType,
+                                          @Param("keyword") String keyword);
 
 
 }

--- a/guardians/src/main/java/com/guardians/dto/board/req/ReqCreateBoardDto.java
+++ b/guardians/src/main/java/com/guardians/dto/board/req/ReqCreateBoardDto.java
@@ -1,11 +1,14 @@
 package com.guardians.dto.board.req;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class ReqCreateBoardDto {
+    @NotBlank(message = "제목은 필수입니다.")
     private String title;
+    @NotBlank(message = "내용은 필수입니다.")
     private String content;
 }

--- a/guardians/src/main/java/com/guardians/dto/board/res/ResBoardListDto.java
+++ b/guardians/src/main/java/com/guardians/dto/board/res/ResBoardListDto.java
@@ -1,5 +1,6 @@
 package com.guardians.dto.board.res;
 
+import com.guardians.domain.board.entity.Board;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,4 +15,17 @@ public class ResBoardListDto {
     private int viewCount;
     private int likeCount;
     private LocalDateTime createdAt;
+    private String boardType;
+
+    public static ResBoardListDto fromEntity(Board board) {
+        return ResBoardListDto.builder()
+                .boardId(board.getId())
+                .title(board.getTitle())
+                .username(board.getUser().getUsername())
+                .createdAt(board.getCreatedAt()) // 날짜 형식 필요시 포맷팅
+                .likeCount(board.getLikeCount())
+                .viewCount(board.getViewCount())
+                .boardType(board.getBoardType().name())
+                .build();
+    }
 }

--- a/guardians/src/main/java/com/guardians/dto/common/ResWrapper.java
+++ b/guardians/src/main/java/com/guardians/dto/common/ResWrapper.java
@@ -55,4 +55,16 @@ public class ResWrapper<T> {
                         .build())
                 .build();
     }
+
+    public static ResWrapper<ErrorResult> resError(String message) {
+        return ResWrapper.<ErrorResult>builder()
+                .result(ErrorResult.builder()
+                        .status(400)
+                        .errorCode(1001)
+                        .message(message)
+                        .build())
+                .build();
+    }
+
+
 }

--- a/guardians/src/main/java/com/guardians/service/board/BoardService.java
+++ b/guardians/src/main/java/com/guardians/service/board/BoardService.java
@@ -15,6 +15,8 @@ public interface BoardService {
 
     List<ResBoardListDto> getBoardList(BoardType boardType);
 
+    List<ResBoardListDto> getBoardList(BoardType boardType, String keyword);
+
     ResBoardDetailDto getBoardDetail(Long boardId, Long userId);
 
     ResUpdateBoardDto updateBoard(Long userId, Long boardId, ReqUpdateBoardDto dto);

--- a/guardians/src/main/java/com/guardians/service/board/BoardServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/board/BoardServiceImpl.java
@@ -70,6 +70,22 @@ public class BoardServiceImpl implements BoardService {
                 .createdAt(board.getCreatedAt())
                 .build()).collect(Collectors.toList());
     }
+
+    @Override
+    public List<ResBoardListDto> getBoardList(BoardType boardType, String keyword) {
+        List<Board> boards;
+
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            boards = boardRepository.findByBoardTypeAndKeyword(boardType, keyword.trim());
+        } else {
+            boards = boardRepository.findByBoardType(boardType);
+        }
+
+        return boards.stream()
+                .map(ResBoardListDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
     @Transactional
     @Override
     public ResBoardDetailDto getBoardDetail(Long boardId,Long userId) {


### PR DESCRIPTION
## 📌 PR 제목
- `feat: implement keyword search and validation for board API`

---

## ✨ 주요 변경사항
- 게시글 등록 요청 시 제목 및 내용에 대한 유효성 검사 추가
- 유효성 검사 실패 시 표준화된 에러 응답 반환 (`ResWrapper.resError`)
- 게시글 목록 조회 시 키워드 기반 검색 기능 추가 (`type + keyword`)
- 키워드가 없을 경우 전체 게시글 조회로 fallback
- 키워드 길이가 2자 미만일 경우 `400 Bad Request` 응답
- LazyInitializationException 해결을 위한 @EntityGraph 적용

---

## 🔍 상세 설명
- 사용자 경험 향상을 위해 제목과 내용이 비어 있을 경우 게시글 등록을 차단하고 메시지를 반환하도록 수정
- 검색 기능 추가로 게시글 목록을 필터링 가능하게 구현 (`title`, `content` 포함 여부 기반)
- 기존 전체 조회 API에 `keyword` 파라미터를 optional하게 추가하여 기능 확장
- Hibernate Lazy 로딩 예외가 발생하지 않도록 게시글과 작성자(User) 간 연관관계를 @EntityGraph로 미리 fetch

---

## ✅ 확인 리스트
- [x] 기능 정상 동작 확인
- [x] 에러 핸들링 및 예외 처리 확인
- [x] API 응답 형식 일관성 확인
- [x] 불필요한 로그/주석 제거

---

## 🧪 테스트 결과
- [x] Postman으로 게시글 등록 및 검색 API 검증
- [x] 프론트 연동 테스트 완료 (유효성 검사 및 키워드 검색 정상 작동)
- [ ] 유닛/통합 테스트 포함 (추후 작성 예정)

---

## 📎 관련 이슈

---

## 💬 기타 공유사항
- 검색 결과가 비어 있거나 조건에 맞지 않을 경우에도 API가 정상 응답하도록 처리됨  
- 추후 게시판 페이징 및 정렬 기능 추가 고려 중
