### PR TITLE
feat : Add radar chart API for Dashboard page

### DIFF
--- a/guardians/src/main/java/com/guardians/controller/DashboardController.java
+++ b/guardians/src/main/java/com/guardians/controller/DashboardController.java
@@ -1,0 +1,39 @@
+package com.guardians.controller;
+
+import com.guardians.dto.dashboard.ResRadarChartDto;
+import com.guardians.dto.common.ResWrapper;
+import com.guardians.exception.CustomException;
+import com.guardians.exception.ErrorCode;
+import com.guardians.service.dashboard.DashboardService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users/{userId}/dashboard")
+@RequiredArgsConstructor
+@Tag(name = "Dashboard API", description = "사용자별 대시보드 통계 API")
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    @Operation(summary = "카테고리별 정규화 점수 조회", description = "레이더 차트용 실력 점수를 조회합니다.")
+    @GetMapping("/radar")
+    public ResponseEntity<ResWrapper<?>> getRadarChart(
+            @PathVariable Long userId,
+            HttpSession session
+    ) {
+        Long sessionUserId = (Long) session.getAttribute("userId");
+        if (!userId.equals(sessionUserId)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        List<ResRadarChartDto.CategoryScore> result = dashboardService.calculateRadarChart(userId);
+        return ResponseEntity.ok(ResWrapper.resList("카테고리별 실력 점수 조회 성공", result, result.size()));
+    }
+}

--- a/guardians/src/main/java/com/guardians/domain/wargame/repository/SolvedWargameRepository.java
+++ b/guardians/src/main/java/com/guardians/domain/wargame/repository/SolvedWargameRepository.java
@@ -53,4 +53,14 @@ public interface SolvedWargameRepository extends JpaRepository<SolvedWargame, So
 
     long countByUserAndWargame_Difficulty(User user, Difficulty difficulty);
 
+    @Query("""
+    SELECT sw FROM SolvedWargame sw
+    JOIN FETCH sw.wargame w
+    JOIN FETCH w.category c
+    WHERE sw.user.id = :userId AND c.name = :categoryName
+""")
+    List<SolvedWargame> findByUserIdAndCategoryName(
+            @Param("userId") Long userId,
+            @Param("categoryName") String categoryName
+    );
 }

--- a/guardians/src/main/java/com/guardians/domain/wargame/repository/WargameRepository.java
+++ b/guardians/src/main/java/com/guardians/domain/wargame/repository/WargameRepository.java
@@ -32,4 +32,10 @@ public interface WargameRepository extends JpaRepository<Wargame, Long> {
     @Query("SELECT w FROM Wargame w JOIN FETCH w.category WHERE w.id = :id")
     Optional<Wargame> findByIdWithCategory(@Param("id") Long id);
 
+    @Query("""
+    SELECT w FROM Wargame w
+    JOIN FETCH w.category c
+    WHERE c.name = :categoryName
+""")
+    List<Wargame> findByCategoryName(@Param("categoryName") String categoryName);
 }

--- a/guardians/src/main/java/com/guardians/dto/dashboard/ResRadarChartDto.java
+++ b/guardians/src/main/java/com/guardians/dto/dashboard/ResRadarChartDto.java
@@ -1,0 +1,21 @@
+package com.guardians.dto.dashboard;
+
+import lombok.*;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ResRadarChartDto {
+    private List<CategoryScore> scores;
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class CategoryScore {
+        private String category;
+        private double normalizedScore;
+    }
+}

--- a/guardians/src/main/java/com/guardians/service/dashboard/DashboardService.java
+++ b/guardians/src/main/java/com/guardians/service/dashboard/DashboardService.java
@@ -1,0 +1,8 @@
+package com.guardians.service.dashboard;
+
+import com.guardians.dto.dashboard.ResRadarChartDto;
+import java.util.List;
+
+public interface DashboardService {
+    List<ResRadarChartDto.CategoryScore> calculateRadarChart(Long userId);
+}

--- a/guardians/src/main/java/com/guardians/service/dashboard/DashboardServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/dashboard/DashboardServiceImpl.java
@@ -1,0 +1,51 @@
+package com.guardians.service.dashboard;
+
+import com.guardians.dto.dashboard.ResRadarChartDto;
+import com.guardians.domain.wargame.entity.SolvedWargame;
+import com.guardians.domain.wargame.entity.Wargame;
+import com.guardians.domain.wargame.repository.SolvedWargameRepository;
+import com.guardians.domain.wargame.repository.WargameRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DashboardServiceImpl implements DashboardService {
+
+    private final SolvedWargameRepository solvedRepo;
+    private final WargameRepository wargameRepo;
+
+    @Override
+    public List<ResRadarChartDto.CategoryScore> calculateRadarChart(Long userId) {
+        List<String> categories = List.of("Web", "Crypto", "Forensic", "BruteForce", "SourceLeak");
+        List<ResRadarChartDto.CategoryScore> scores = new ArrayList<>();
+
+        for (String category : categories) {
+            List<Wargame> allProblems = wargameRepo.findByCategoryName(category);
+            List<SolvedWargame> userSolved = solvedRepo.findByUserIdAndCategoryName(userId, category);
+
+            int totalScore = allProblems.stream().mapToInt(Wargame::getScore).sum();
+            int totalCount = allProblems.size();
+
+            int userScore = userSolved.stream().mapToInt(sw -> sw.getWargame().getScore()).sum();
+            int userCount = userSolved.size();
+
+            double raw = userScore * (1 + Math.log(Math.max(1, userCount)));
+            double maxRaw = totalScore * (1 + Math.log(Math.max(1, totalCount)));
+
+            double normalized = maxRaw == 0 ? 0 : (raw / maxRaw) * 100;
+
+            scores.add(
+                    ResRadarChartDto.CategoryScore.builder()
+                            .category(category)
+                            .normalizedScore(normalized)
+                            .build()
+            );
+        }
+
+        return scores;
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
feat : 대시보드 페이지에 레이더 차트 기능 추가


---

## ✨ 주요 변경사항
- /api/users/{userId}/dashboard/radar API 추가

- DashboardServiceImpl.calculateRadarChart() 로직 구현

- ResRadarChartDto.CategoryScore 응답 DTO 생성

- 사용자별 카테고리 정규화 점수 계산 로직 적용

**정규화 수식 :**
```
normalizedScore = (userCategoryScore / maxCategoryScore) * 100
```

---

## 🔍 상세 설명
1. 사용자가 로그인한 상태에서 /dashboard 접근

2. 백엔드 /api/users/{userId}/dashboard/radar 호출

3. 사용자의 SolvedWargame 기록을 바탕으로 카테고리별 누적 점수를 계산

4. 해당 카테고리에서 가장 높은 점수 대비 정규화된 점수 반환

**수식 설명 :**
```
- 카테고리마다 난이도나 점수 분포가 다를 수 있기 때문에, 절대 점수로 비교하면 왜곡될 수 있음

- 그래서 각 카테고리 내에서 가장 높은 점수를 기준점(100점)으로 삼고, 사용자의 점수를 비율로 환산함

- ex) 어떤 사용자가 Web 카테고리에서 300점을 받고 해당 카테고리 최고점이 600점이라면,

이 사용자의 정규화 점수는 (300 / 600) * 100 = 50점으로 표시됨

- 이렇게 하면 사용자마다 실력의 상대적 수준을 공정하게 비교할 수 있음
```


6. 프론트엔드 RadarChart.tsx에서 Recharts 기반 시각화
---

## ✅ 확인 리스트
- [x] 기능 정상 동작 확인
- [x] 에러 핸들링 및 예외 처리 확인
- [x] API 응답 형식 일관성 확인
- [ ] 불필요한 로그/주석 제거

---

## 🧪 테스트 결과
- [x] Postman/Swagger로 API 테스트
- [x] 프론트에서 연동 확인
- [ ] 유닛/통합 테스트 포함 (있다면)

---

## 📎 관련 이슈


---

## 💬 기타 공유사항
- Dashboard 관련 Controller, DTO, Service 새로 만듦
- 기존 코드에서 WargameRepository와 SolvedWargameRepository에 추가된 메서드 있음
