### PR TITLE
feat: add API to increment question view count

### DIFF
--- a/guardians/src/main/java/com/guardians/controller/BoardController.java
+++ b/guardians/src/main/java/com/guardians/controller/BoardController.java
@@ -83,8 +83,7 @@ public class BoardController {
         ResBoardDetailDto result = boardService.getBoardDetail(boardId, userId);
         return ResponseEntity.ok(ResWrapper.resSuccess("게시글 상세 조회 성공", result));
     }
-
-
+    
     // 게시글 수정
     @Operation(summary = "게시글 수정", description = "게시글 작성자만 게시글을 수정할 수 있습니다.")
     @PatchMapping("/{boardId}")

--- a/guardians/src/main/java/com/guardians/controller/QnaController.java
+++ b/guardians/src/main/java/com/guardians/controller/QnaController.java
@@ -20,6 +20,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import static org.springframework.data.jpa.domain.AbstractPersistable_.id;
+
 @RestController
 @RequestMapping("/api/qna")
 @RequiredArgsConstructor

--- a/guardians/src/main/java/com/guardians/domain/board/entity/Question.java
+++ b/guardians/src/main/java/com/guardians/domain/board/entity/Question.java
@@ -46,4 +46,21 @@ public class Question {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    @Builder.Default
+    @Column(nullable = true, name = "view_count")
+    private Integer viewCount = 0;
+
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        if (viewCount == null) {
+            viewCount = 0;
+        }
+    }
+
+
+
 }

--- a/guardians/src/main/java/com/guardians/domain/board/repository/BoardRepository.java
+++ b/guardians/src/main/java/com/guardians/domain/board/repository/BoardRepository.java
@@ -16,6 +16,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query("SELECT b FROM Board b JOIN FETCH b.user WHERE b.boardType = :boardType")
     List<Board> findByBoardType(@Param("boardType") BoardType boardType);
+
     @Query("SELECT b FROM Board b JOIN FETCH b.user WHERE b.id = :id")
     Optional<Board> findByIdWithUser(@Param("id") Long id);
 

--- a/guardians/src/main/java/com/guardians/domain/user/entity/UserStats.java
+++ b/guardians/src/main/java/com/guardians/domain/user/entity/UserStats.java
@@ -35,7 +35,7 @@ public class UserStats {
     private LocalDateTime updatedAt;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = true)
     private Tier tier;
 
     public void addScore(int scoreToAdd) {

--- a/guardians/src/main/java/com/guardians/dto/question/res/ResQuestionDetailDto.java
+++ b/guardians/src/main/java/com/guardians/dto/question/res/ResQuestionDetailDto.java
@@ -5,6 +5,7 @@ package com.guardians.dto.question.res;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import software.amazon.awssdk.services.s3.endpoints.internal.Value;
 
 import java.time.LocalDateTime;
 
@@ -16,8 +17,10 @@ public class ResQuestionDetailDto {
     private String title;
     private String content;
     private String username;
+    private String userId;
     private Long wargameId;
     private String wargameTitle;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private int viewCount;
 }

--- a/guardians/src/main/java/com/guardians/dto/question/res/ResQuestionListDto.java
+++ b/guardians/src/main/java/com/guardians/dto/question/res/ResQuestionListDto.java
@@ -16,5 +16,8 @@ public class ResQuestionListDto {
     private String title;
     private String content;
     private String username;
+    private Long wargameId;
+    private String wargameTitle;
     private LocalDateTime createdAt;
+    private int viewCount;
 }

--- a/guardians/src/main/java/com/guardians/service/answer/AnswerServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/answer/AnswerServiceImpl.java
@@ -65,7 +65,6 @@ public class AnswerServiceImpl implements AnswerService {
 
     @Override
     public List<ResAnswerListDto> getAnswerListByQuestion(Long questionId) {
-        // Fetch join으로 N+1 방지
         List<Answer> answers = answerRepository.findAllWithUserByQuestionId(questionId);
 
         List<ResAnswerListDto> result = new ArrayList<>();
@@ -80,6 +79,7 @@ public class AnswerServiceImpl implements AnswerService {
         }
         return result;
     }
+
 
     @Override
     public ResUpdateAnswerDto updateAnswer(Long userId, Long answerId, ReqUpdateAnswerDto dto) {

--- a/guardians/src/main/java/com/guardians/service/question/QuestionService.java
+++ b/guardians/src/main/java/com/guardians/service/question/QuestionService.java
@@ -6,7 +6,10 @@ import com.guardians.dto.question.res.ResCreateQuestionDto;
 import com.guardians.dto.question.res.ResQuestionDetailDto;
 import com.guardians.dto.question.res.ResQuestionListDto;
 import com.guardians.dto.question.res.ResUpdateQuestionDto;
+import jakarta.persistence.metamodel.SingularAttribute;
+import org.springframework.data.jpa.domain.AbstractPersistable;
 
+import java.io.Serializable;
 import java.util.List;
 
 public interface QuestionService {
@@ -22,4 +25,7 @@ public interface QuestionService {
     ResUpdateQuestionDto updateQuestion(Long userId, Long questionId, ReqUpdateQuestionDto dto);
 
     void deleteQuestion(Long userId, Long questionId);
+
+    void increaseViewCount(Long questionId);
+
 }

--- a/guardians/src/main/java/com/guardians/service/question/QuestionServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/question/QuestionServiceImpl.java
@@ -46,6 +46,7 @@ public class QuestionServiceImpl implements QuestionService {
                 .wargame(wargame)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
+                .viewCount(0)
                 .build();
 
         Question saved = questionRepository.save(question);
@@ -66,7 +67,10 @@ public class QuestionServiceImpl implements QuestionService {
                         .title(q.getTitle())
                         .content(q.getContent())
                         .username(q.getUser().getUsername())
+                        .wargameTitle(q.getWargame().getTitle())
+                        .wargameId(q.getWargame().getId())
                         .createdAt(q.getCreatedAt())
+                        .viewCount(q.getViewCount())
                         .build())
                 .collect(Collectors.toList());
     }
@@ -82,6 +86,7 @@ public class QuestionServiceImpl implements QuestionService {
                         .content(q.getContent())
                         .username(q.getUser().getUsername())
                         .createdAt(q.getCreatedAt())
+                        .viewCount(q.getViewCount())
                         .build())
                 .collect(Collectors.toList());
     }
@@ -91,8 +96,11 @@ public class QuestionServiceImpl implements QuestionService {
         Question question = questionRepository.findByIdWithUserAndWargame(questionId)
                 .orElseThrow(() -> new CustomException(ErrorCode.QUESTION_NOT_FOUND));
 
+        question.increaseViewCount();
+
         return ResQuestionDetailDto.builder()
                 .id(question.getId())
+                .userId(String.valueOf(question.getUser().getId()))
                 .title(question.getTitle())
                 .content(question.getContent())
                 .username(question.getUser().getUsername())
@@ -100,6 +108,7 @@ public class QuestionServiceImpl implements QuestionService {
                 .wargameTitle(question.getWargame().getTitle())
                 .createdAt(question.getCreatedAt())
                 .updatedAt(question.getUpdatedAt())
+                .viewCount(question.getViewCount())
                 .build();
     }
 
@@ -135,4 +144,13 @@ public class QuestionServiceImpl implements QuestionService {
 
         questionRepository.delete(question);
     }
+
+    @Override
+    public void increaseViewCount(Long questionId) {
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUESTION_NOT_FOUND));
+        question.increaseViewCount();  // 🔥 엔티티 메서드 호출
+    }
+
+
 }


### PR DESCRIPTION
## 📌 PR 제목
- feat: add API to increment question view count
---

## ✨ 주요 변경사항
- `QuestionService.getQuestionDetail` 호출 시 해당 질문의 `viewCount`를 증가하도록 로직 추가
- 별도의 조회수 증가 API 없이, 질문 상세 조회(`GET /api/qna/questions/{questionId}`) 시 자동으로 카운트 증가
- ResWrapper 포맷 유지 및 응답 결과는 기존과 동일

---

## 🔍 상세 설명
- QnA 질문 상세 페이지 진입 시 `/api/qna/questions/{questionId}` API 호출로 조회수 증가 처리
- `QuestionService` 내에서 DB의 `viewCount` 필드 값을 증가 처리
- 질문 존재 여부 확인 및 예외 처리 유지 (존재하지 않을 경우 404 응답)
- 클라이언트 호출 시 별도의 조회수 증가 API 호출 필요 없이 자동 증가

---

## ✅ 확인 리스트
- [x] 기능 정상 동작 확인 (조회수 증가 및 DB 반영)
- [x] 에러 핸들링 및 예외 처리 확인 (질문 미존재 시 404 반환)
- [x] API 응답 형식 일관성 확인 (ResWrapper 포맷)
- [x] 불필요한 로그/주석 제거

---

## 🧪 테스트 결과
- [x] Postman으로 `/api/qna/questions/{questionId}` 호출 시 조회수 증가 확인
- [x] DB에서 viewCount 값 증가 확인
- [ ] 유닛/통합 테스트 포함 (후속 작업으로 예정)

---

## 📎 관련 이슈
Closes #42

---

## 💬 기타 공유사항
- 클라이언트 진입 시 자동 조회수 증가 처리, 중복 호출 방지는 후속 고려
