### PR TITLE
feat : add score trend logic for Dashboard

### DIFF
--- a/guardians/src/main/java/com/guardians/controller/DashboardController.java
+++ b/guardians/src/main/java/com/guardians/controller/DashboardController.java
@@ -55,4 +55,19 @@ public class DashboardController {
         List<ResSolvedTimelineDto> result = dashboardService.getSolvedTimeline(userId);
         return ResponseEntity.ok(ResWrapper.resList("풀이 타임라인 조회 성공", result, result.size()));
     }
+
+    @Operation(summary = "사용자의 날짜별 점수 획득 추이 조회", description = "문제 풀이 기록을 기반으로 날짜별 획득 점수를 반환합니다.")
+    @GetMapping("/score-trend")
+    public ResponseEntity<ResWrapper<?>> getScoreTrend(
+            @PathVariable Long userId,
+            HttpSession session
+    ) {
+        Long sessionUserId = (Long) session.getAttribute("userId");
+        if (!userId.equals(sessionUserId)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        var result = dashboardService.getScoreTrend(userId);
+        return ResponseEntity.ok(ResWrapper.resList("점수 추이 조회 성공", result, result.size()));
+    }
 }

--- a/guardians/src/main/java/com/guardians/dto/dashboard/ResScoreTrendDto.java
+++ b/guardians/src/main/java/com/guardians/dto/dashboard/ResScoreTrendDto.java
@@ -1,0 +1,8 @@
+package com.guardians.dto.dashboard;
+
+import java.time.LocalDate;
+
+public record ResScoreTrendDto(
+        LocalDate date,
+        int earnedScore
+) {}

--- a/guardians/src/main/java/com/guardians/service/dashboard/DashboardService.java
+++ b/guardians/src/main/java/com/guardians/service/dashboard/DashboardService.java
@@ -1,6 +1,7 @@
 package com.guardians.service.dashboard;
 
 import com.guardians.dto.dashboard.ResRadarChartDto;
+import com.guardians.dto.dashboard.ResScoreTrendDto;
 import com.guardians.dto.dashboard.ResSolvedTimelineDto;
 
 import java.util.List;
@@ -9,4 +10,6 @@ public interface DashboardService {
     List<ResRadarChartDto.CategoryScore> calculateRadarChart(Long userId);
 
     List<ResSolvedTimelineDto> getSolvedTimeline(Long userId);
+
+    List<ResScoreTrendDto> getScoreTrend(Long userId);
 }


### PR DESCRIPTION
## 📌 PR 제목
feat: 대시보드용 점수 변화 로직 추가

---

## ✨ 주요 변경사항
- DashboardServiceImpl에 getScoreTrend() 메서드 추가

- 사용자가 문제를 푼 날짜 기준으로 점수를 집계하여 ResScoreTrendDto로 응답

- SolvedWargame 엔티티에서 날짜별 점수를 추출하고 정렬된 리스트로 반환


---

## 🔍 상세 설명
- 대시보드에 사용자의 일별 점수 획득 추이를 시각화하기 위해 점수 변화 로직 구현

- SolvedWargameRepository를 통해 유저별 문제 풀이 데이터를 조회하고, 날짜별로 점수를 집계

- 프론트엔드에서 일자별 점수 라인차트 구성을 위한 API(/api/users/{userId}/dashboard/score-trend)에 사용
---

## ✅ 확인 리스트
- [x] 기능 정상 동작 확인
- [x] 에러 핸들링 및 예외 처리 확인
- [x] API 응답 형식 일관성 확인
- [ ] 불필요한 로그/주석 제거

---

## 🧪 테스트 결과
- [x] Postman/Swagger로 API 테스트
- [x] 프론트에서 연동 확인
- [ ] 유닛/통합 테스트 포함 (있다면)

---

## 📎 관련 이슈


---

## 💬 기타 공유사항

