### PR TITLE
refact: 도메인 캡슐화 및 중복 로직 제거

### DIFF
--- a/guardians/src/main/java/com/guardians/domain/board/entity/Answer.java
+++ b/guardians/src/main/java/com/guardians/domain/board/entity/Answer.java
@@ -35,4 +35,9 @@ public class Answer {
 
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    public void updateContent(String content) {
+        this.content = content;
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/guardians/src/main/java/com/guardians/domain/board/entity/Board.java
+++ b/guardians/src/main/java/com/guardians/domain/board/entity/Board.java
@@ -71,4 +71,18 @@ public class Board {
         this.viewCount++;
     }
 
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+        this.updatedAt = LocalDateTime.now();  // 항상 같이 갱신
+    }
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        this.likeCount = Math.max(0, this.likeCount - 1);
+    }
+
 }

--- a/guardians/src/main/java/com/guardians/domain/board/entity/Comment.java
+++ b/guardians/src/main/java/com/guardians/domain/board/entity/Comment.java
@@ -39,4 +39,8 @@ public class Comment {
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
     }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/guardians/src/main/java/com/guardians/domain/board/entity/Question.java
+++ b/guardians/src/main/java/com/guardians/domain/board/entity/Question.java
@@ -61,6 +61,9 @@ public class Question {
         }
     }
 
-
-
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/guardians/src/main/java/com/guardians/domain/job/entity/Job.java
+++ b/guardians/src/main/java/com/guardians/domain/job/entity/Job.java
@@ -63,4 +63,11 @@ public class Job {
         this.updatedAt = LocalDateTime.now();
     }
 
+    public void update(String title, String description, String salary, LocalDate deadline, Boolean isActive) {
+        this.title = title;
+        this.description = description;
+        this.salary = salary;
+        this.deadline = deadline;
+        this.isActive = isActive;
+    }
 }

--- a/guardians/src/main/java/com/guardians/domain/wargame/entity/Review.java
+++ b/guardians/src/main/java/com/guardians/domain/wargame/entity/Review.java
@@ -51,4 +51,8 @@ public class Review {
     protected void onUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/guardians/src/main/java/com/guardians/domain/wargame/entity/Wargame.java
+++ b/guardians/src/main/java/com/guardians/domain/wargame/entity/Wargame.java
@@ -69,4 +69,11 @@ public class Wargame {
     @OneToMany(mappedBy = "wargame", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Question> questions = new ArrayList<>();
 
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        this.likeCount = Math.max(0, this.likeCount - 1);
+    }
 }

--- a/guardians/src/main/java/com/guardians/service/answer/AnswerServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/answer/AnswerServiceImpl.java
@@ -93,8 +93,7 @@ public class AnswerServiceImpl implements AnswerService {
         }
 
         // 수정
-        answer.setContent(dto.getContent());
-        answer.setUpdatedAt(LocalDateTime.now());
+        answer.updateContent(dto.getContent());
 
         // 저장
         Answer updated = answerRepository.save(answer);

--- a/guardians/src/main/java/com/guardians/service/board/BoardServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/board/BoardServiceImpl.java
@@ -36,6 +36,7 @@ public class BoardServiceImpl implements BoardService {
     private final CommentRepository commentRepository;
 
 
+    @Transactional
     @Override
     public ResCreateBoardDto createBoard(Long userId, ReqCreateBoardDto dto, BoardType boardType) {
         User user = userRepository.findById(userId)
@@ -60,38 +61,30 @@ public class BoardServiceImpl implements BoardService {
                 .build();
     }
 
+    @Transactional
     @Override
     public List<ResBoardListDto> getBoardList(BoardType boardType) {
-        List<Board> boards = boardRepository.findByBoardType(boardType);
-
-        Map<Long, Long> commentCountMap = commentRepository.countCommentsByBoard().stream()
-                .collect(Collectors.toMap(
-                        projection -> projection.getBoardId(),
-                        projection -> projection.getCommentCount()
-                ));
-        return boards.stream()
-                .map(board -> ResBoardListDto.fromEntity(board)
-                        .toBuilder()
-                        .commentCount(commentCountMap.getOrDefault(board.getId(), 0L))
-                        .build())
-                .collect(Collectors.toList());
+        return getBoardList(boardType, null);
     }
 
+    @Transactional
     @Override
     public List<ResBoardListDto> getBoardList(BoardType boardType, String keyword) {
-        List<Board> boards;
+        List<Board> boards = (keyword != null && !keyword.trim().isEmpty())
+                ? boardRepository.findByBoardTypeAndKeyword(boardType, keyword.trim())
+                : boardRepository.findByBoardType(boardType);
 
-        if (keyword != null && !keyword.trim().isEmpty()) {
-            boards = boardRepository.findByBoardTypeAndKeyword(boardType, keyword.trim());
-        } else {
-            boards = boardRepository.findByBoardType(boardType);
-        }
+        return toBoardListDtos(boards);
+    }
 
+    @Transactional
+    private List<ResBoardListDto> toBoardListDtos(List<Board> boards) {
         Map<Long, Long> commentCountMap = commentRepository.countCommentsByBoard().stream()
                 .collect(Collectors.toMap(
                         CommentCountRepository::getBoardId,
                         CommentCountRepository::getCommentCount
                 ));
+
         return boards.stream()
                 .map(board -> ResBoardListDto.fromEntity(board)
                         .toBuilder()
@@ -134,9 +127,7 @@ public class BoardServiceImpl implements BoardService {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
-        board.setTitle(dto.getTitle());
-        board.setContent(dto.getContent());
-        board.setUpdatedAt(LocalDateTime.now());
+	board.update(dto.getTitle(), dto.getContent());
 
         Board updatedBoard = boardRepository.save(board);
 
@@ -150,6 +141,7 @@ public class BoardServiceImpl implements BoardService {
                 .build();
     }
 
+    @Transactional
     @Override
     public void deleteBoard(Long userId, Long boardId) {
         Board board = boardRepository.findByIdWithUser(boardId)
@@ -175,13 +167,13 @@ public class BoardServiceImpl implements BoardService {
 
         if (existing.isPresent()) {
             boardLikeRepository.delete(existing.get());
-            board.setLikeCount(board.getLikeCount() - 1);
+            board.decreaseLikeCount();
             boardRepository.save(board);
             return false; // 좋아요 취소
         } else {
             BoardLike like = BoardLike.of(user, board);
             boardLikeRepository.save(like);
-            board.setLikeCount(board.getLikeCount() + 1);
+            board.increaseLikeCount();
             boardRepository.save(board);
             return true; // 좋아요 등록
         }

--- a/guardians/src/main/java/com/guardians/service/board/CommentServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/board/CommentServiceImpl.java
@@ -77,7 +77,7 @@ public class CommentServiceImpl implements CommentService {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
-        comment.setContent(dto.getContent());
+        comment.updateContent(dto.getContent());
         commentRepository.save(comment);
 
         // 저장한 뒤 다시 조회 (user를 fetch join해서 username 접근 가능하게)

--- a/guardians/src/main/java/com/guardians/service/job/JobServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/job/JobServiceImpl.java
@@ -76,12 +76,7 @@ public class JobServiceImpl implements JobService {
         Job job = jobRepository.findById(jobId)
                 .orElseThrow(() -> new CustomException(ErrorCode.JOB_NOT_FOUND));
 
-        job.setTitle(dto.getTitle());
-        job.setDescription(dto.getDescription());
-        job.setSalary(dto.getSalary());
-        job.setDeadline(dto.getDeadline());
-        job.setIsActive(dto.getIsActive());
-        job.setUpdatedAt(LocalDateTime.now());
+        job.update(dto.getTitle(), dto.getDescription(), dto.getSalary(), dto.getDeadline(), dto.getIsActive());
     }
 
     @Override

--- a/guardians/src/main/java/com/guardians/service/question/QuestionServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/question/QuestionServiceImpl.java
@@ -123,9 +123,7 @@ public class QuestionServiceImpl implements QuestionService {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
-        question.setTitle(dto.getTitle());
-        question.setContent(dto.getContent());
-        question.setUpdatedAt(LocalDateTime.now());
+        question.update(dto.getTitle(), dto.getContent());
 
         Question updated = questionRepository.save(question);
 

--- a/guardians/src/main/java/com/guardians/service/user/impl/UserServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/user/impl/UserServiceImpl.java
@@ -42,6 +42,11 @@ public class UserServiceImpl implements UserService {
         }
     }
 
+    private User getUserWithStats(Long userId) {
+        return userRepository.findWithStatsById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
     @Transactional
     @Override
     public ResCreateUserDto createUser(ReqCreateUserDto dto) {
@@ -104,9 +109,7 @@ public class UserServiceImpl implements UserService {
             throw new CustomException(ErrorCode.PERMISSION_DENIED); // ← 권한 없음 에러 따로 만들자
         }
 
-        User user = userRepository.findWithStatsById(targetUserId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
+        User user = getUserWithStats(targetUserId);
         user.updateUsername(dto.getUsername());
 
         return ResLoginDto.fromEntity(user);
@@ -119,8 +122,7 @@ public class UserServiceImpl implements UserService {
             throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        User user = userRepository.findWithStatsById(sessionUserId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = getUserWithStats(sessionUserId);
 
         if (!passwordEncoder.matches(dto.getCurrentPassword(), user.getPassword())) {
             throw new CustomException(ErrorCode.INVALID_PASSWORD);
@@ -133,8 +135,7 @@ public class UserServiceImpl implements UserService {
     @Transactional
     @Override
     public void verifyResetPassword(Long userId, String code, String newPassword) {
-        User user = userRepository.findWithStatsById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = getUserWithStats(userId);
 
         boolean verified = emailVerificationService.verifyCode(user.getEmail(), code);
         if (!verified) {
@@ -176,8 +177,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public ResLoginDto getUserInfo(Long userId) {
-        User user = userRepository.findWithStatsById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = getUserWithStats(userId);
 
         return ResLoginDto.builder()
                 .id(user.getId())
@@ -191,9 +191,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public String getEmailByUserId(Long userId) {
-        User user = userRepository.findWithStatsById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        return user.getEmail();
+        return getUserWithStats(userId).getEmail();
     }
 
 
@@ -206,11 +204,7 @@ public class UserServiceImpl implements UserService {
     @Transactional
     @Override
     public void updateProfileImageUrl(Long userId, String imageUrl) {
-        User user = userRepository.findWithStatsById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        user.updateProfileImageUrl(imageUrl);
-        // 변경 감지를 위해 save 호출 불필요 (JPA 엔티티 상태 유지 중)
+        getUserWithStats(userId).updateProfileImageUrl(imageUrl);
     }
 
 }

--- a/guardians/src/main/java/com/guardians/service/wargame/WargameServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/wargame/WargameServiceImpl.java
@@ -87,6 +87,7 @@ public class WargameServiceImpl implements WargameService {
         wargameRepository.delete(wargame);
     }
 
+    @Transactional
     public List<ResWargameListDto> getWargameList(Long userId) {
         List<Wargame> wargames = wargameRepository.findAllWithCategory();
         List<Long> wargameIds = wargames.stream().map(Wargame::getId).toList();
@@ -220,8 +221,7 @@ public class WargameServiceImpl implements WargameService {
 
         if (likeOpt.isPresent()) {
             wargameLikeRepository.delete(likeOpt.get());
-            wargame.setLikeCount(Math.max(0, wargame.getLikeCount() - 1));
-            wargameRepository.save(wargame);
+            wargame.decreaseLikeCount();
             return false;
         } else {
             wargameLikeRepository.save(WargameLike.builder()
@@ -229,8 +229,7 @@ public class WargameServiceImpl implements WargameService {
                     .wargame(wargame)
                     .createdAt(LocalDateTime.now())
                     .build());
-            wargame.setLikeCount(wargame.getLikeCount() + 1);
-            wargameRepository.save(wargame);
+            wargame.increaseLikeCount();
             return true;
         }
     }
@@ -276,8 +275,7 @@ public class WargameServiceImpl implements WargameService {
             throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        review.setContent(request.getContent());
-        review.setUpdatedAt(LocalDateTime.now());
+        review.updateContent(request.getContent());
 
         return ResReviewListDto.fromEntity(review);
     }


### PR DESCRIPTION
## Summary
- Entity 클래스에 비즈니스 로직 메서드 추가하여 도메인 캡슐화
- Service 계층에서 setter 직접 호출 대신 도메인 메서드 사용
- UserServiceImpl, BoardServiceImpl 중복 로직 제거

## Test plan
- [ ] 빌드 확인 (`./gradlew build`)
- [ ] 기존 기능 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)