### PR TITLE
refact: Badge 및 Category 하드코딩 문자열을 Enum으로 변경

### DIFF
--- a/guardians/src/main/java/com/guardians/domain/badge/entity/BadgeType.java
+++ b/guardians/src/main/java/com/guardians/domain/badge/entity/BadgeType.java
@@ -1,15 +1,31 @@
 package com.guardians.domain.badge.entity;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
 public enum BadgeType {
-    BEGINNER,
-    EXPLORER,
-    BRUTE_FORCER,
-    WEB_RAIDER,
-    REVERSE_MASTER,
-    CRYPTO_BREAKER,
-    LEAK_INTRUDER,
-    FIRST_BLOOD,
-    ROOKIE_HACKER,
-    HELL_SURVIVOR,
-    DAILY_GRINDER
+    BEGINNER("입문자"),
+    WARGAME_MASTER("워게임 마스터"),
+    HELL_SURVIVOR("지옥을 맛본 자"),
+    WEB_HACKER("웹 해커"),
+    DIGITAL_TRACKER("디지털 추적자"),
+    CRYPTO_BREAKER("암호 해독자"),
+    BRUTE_FORCER("무차별 해커"),
+    LEAK_INTRUDER("정보 침투자"),
+    EXPLORER("탐험가"),
+    DAILY_GRINDER("꾸준한 해커"),
+    FIRST_BLOOD("퍼스트 블러드");
+
+    private final String displayName;
+
+    public static BadgeType fromDisplayName(String displayName) {
+        return Arrays.stream(values())
+                .filter(type -> type.displayName.equals(displayName))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown badge name: " + displayName));
+    }
 }

--- a/guardians/src/main/java/com/guardians/domain/wargame/entity/CategoryType.java
+++ b/guardians/src/main/java/com/guardians/domain/wargame/entity/CategoryType.java
@@ -1,0 +1,25 @@
+package com.guardians.domain.wargame.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum CategoryType {
+    WEB("Web"),
+    FORENSIC("Forensic"),
+    CRYPTO("Crypto"),
+    BRUTE_FORCE("BruteForce"),
+    SOURCE_LEAK("SourceLeak");
+
+    private final String displayName;
+
+    public static CategoryType fromDisplayName(String displayName) {
+        return Arrays.stream(values())
+                .filter(type -> type.displayName.equals(displayName))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown category name: " + displayName));
+    }
+}

--- a/guardians/src/main/java/com/guardians/service/badge/BadgeServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/badge/BadgeServiceImpl.java
@@ -1,11 +1,13 @@
 package com.guardians.service.badge;
 
 import com.guardians.domain.badge.entity.Badge;
+import com.guardians.domain.badge.entity.BadgeType;
 import com.guardians.domain.badge.entity.UserBadge;
 import com.guardians.domain.badge.repository.BadgeRepository;
 import com.guardians.domain.badge.repository.UserBadgeRepository;
 import com.guardians.domain.user.entity.User;
 import com.guardians.domain.user.repository.UserRepository;
+import com.guardians.domain.wargame.entity.CategoryType;
 import com.guardians.domain.wargame.entity.Difficulty;
 import com.guardians.domain.wargame.repository.SolvedWargameRepository;
 import com.guardians.dto.badge.res.ResUserBadgeDto;
@@ -88,20 +90,20 @@ public class BadgeServiceImpl implements BadgeService {
 
         long totalSolved = solvedWargameRepository.countByUser(user);
 
-        if (totalSolved >= 1 && !owned.contains("입문자")) {
-            assignBadgeIfNeeded(userId, "입문자");
+        if (totalSolved >= 1 && !owned.contains(BadgeType.BEGINNER.getDisplayName())) {
+            assignBadgeIfNeeded(userId, BadgeType.BEGINNER);
         }
 
         // 신참 해커: 5문제 이상
-        if (totalSolved >= 5 && !owned.contains("워게임 마스터")) {
-            assignBadgeIfNeeded(userId, "워게임 마스터");
+        if (totalSolved >= 5 && !owned.contains(BadgeType.WARGAME_MASTER.getDisplayName())) {
+            assignBadgeIfNeeded(userId, BadgeType.WARGAME_MASTER);
         }
 
-// 지옥을 맛본 자: HARD 3문제 이상 해결
+        // 지옥을 맛본 자: HARD 3문제 이상 해결
         long hardCount = solvedWargameRepository.countByUserAndWargame_Difficulty(user, Difficulty.HARD);
 
-        if (hardCount >= 3 && !owned.contains("지옥을 맛본 자")) {
-            assignBadgeIfNeeded(user.getId(), "지옥을 맛본 자");
+        if (hardCount >= 3 && !owned.contains(BadgeType.HELL_SURVIVOR.getDisplayName())) {
+            assignBadgeIfNeeded(user.getId(), BadgeType.HELL_SURVIVOR);
         }
 
         // 카테고리별 풀이 수를 한 번의 쿼리로 조회 (N+1 해결)
@@ -111,36 +113,47 @@ public class BadgeServiceImpl implements BadgeService {
                         row -> (Long) row[1]
                 ));
 
-        if (categoryCountMap.getOrDefault("Web", 0L) >= 3 && !owned.contains("웹 해커")) {
-            assignBadgeIfNeeded(userId, "웹 해커");
+        if (categoryCountMap.getOrDefault(CategoryType.WEB.getDisplayName(), 0L) >= 3
+                && !owned.contains(BadgeType.WEB_HACKER.getDisplayName())) {
+            assignBadgeIfNeeded(userId, BadgeType.WEB_HACKER);
         }
 
-        if (categoryCountMap.getOrDefault("Forensic", 0L) >= 3 && !owned.contains("디지털 추적자")) {
-            assignBadgeIfNeeded(userId, "디지털 추적자");
+        if (categoryCountMap.getOrDefault(CategoryType.FORENSIC.getDisplayName(), 0L) >= 3
+                && !owned.contains(BadgeType.DIGITAL_TRACKER.getDisplayName())) {
+            assignBadgeIfNeeded(userId, BadgeType.DIGITAL_TRACKER);
         }
 
-        if (categoryCountMap.getOrDefault("Crypto", 0L) >= 3 && !owned.contains("암호 해독자")) {
-            assignBadgeIfNeeded(userId, "암호 해독자");
+        if (categoryCountMap.getOrDefault(CategoryType.CRYPTO.getDisplayName(), 0L) >= 3
+                && !owned.contains(BadgeType.CRYPTO_BREAKER.getDisplayName())) {
+            assignBadgeIfNeeded(userId, BadgeType.CRYPTO_BREAKER);
         }
 
-        if (categoryCountMap.getOrDefault("BruteForce", 0L) >= 3 && !owned.contains("무차별 해커")) {
-            assignBadgeIfNeeded(userId, "무차별 해커");
+        if (categoryCountMap.getOrDefault(CategoryType.BRUTE_FORCE.getDisplayName(), 0L) >= 3
+                && !owned.contains(BadgeType.BRUTE_FORCER.getDisplayName())) {
+            assignBadgeIfNeeded(userId, BadgeType.BRUTE_FORCER);
         }
 
-        if (categoryCountMap.getOrDefault("SourceLeak", 0L) >= 3 && !owned.contains("정보 침투자")) {
-            assignBadgeIfNeeded(userId, "정보 침투자");
+        if (categoryCountMap.getOrDefault(CategoryType.SOURCE_LEAK.getDisplayName(), 0L) >= 3
+                && !owned.contains(BadgeType.LEAK_INTRUDER.getDisplayName())) {
+            assignBadgeIfNeeded(userId, BadgeType.LEAK_INTRUDER);
         }
 
         // 탐험가: 모든 카테고리 하나씩 (keySet으로 확인)
-        Set<String> allCategories = Set.of("Web", "Forensic", "Crypto", "BruteForce", "SourceLeak");
-        if (categoryCountMap.keySet().containsAll(allCategories) && !owned.contains("탐험가")) {
-            assignBadgeIfNeeded(userId, "탐험가");
+        Set<String> allCategories = Set.of(
+                CategoryType.WEB.getDisplayName(),
+                CategoryType.FORENSIC.getDisplayName(),
+                CategoryType.CRYPTO.getDisplayName(),
+                CategoryType.BRUTE_FORCE.getDisplayName(),
+                CategoryType.SOURCE_LEAK.getDisplayName()
+        );
+        if (categoryCountMap.keySet().containsAll(allCategories) && !owned.contains(BadgeType.EXPLORER.getDisplayName())) {
+            assignBadgeIfNeeded(userId, BadgeType.EXPLORER);
         }
 
         // 꾸준한 해커: 7일 연속
         boolean solved7Days = solvedWargameRepository.checkSolved7DaysInARow(userId);
-        if (solved7Days && !owned.contains("꾸준한 해커")) {
-            assignBadgeIfNeeded(userId, "꾸준한 해커");
+        if (solved7Days && !owned.contains(BadgeType.DAILY_GRINDER.getDisplayName())) {
+            assignBadgeIfNeeded(userId, BadgeType.DAILY_GRINDER);
         }
     }
 
@@ -150,7 +163,7 @@ public class BadgeServiceImpl implements BadgeService {
         // 첫 해결자인지 확인하기 전에, 해당 유저가 '퍼스트 블러드' 뱃지를 이미 가지고 있는지 먼저 확인합니다.
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
-        boolean hasFirstBlood = userBadgeRepository.existsByUserAndBadge_Name(user, "퍼스트 블러드");
+        boolean hasFirstBlood = userBadgeRepository.existsByUserAndBadge_Name(user, BadgeType.FIRST_BLOOD.getDisplayName());
 
         // 이미 뱃지가 있다면 더 이상 진행하지 않습니다.
         // (참고: 문제마다 퍼스트블러드를 주고 싶다면 이 로직은 변경되어야 합니다.)
@@ -169,17 +182,17 @@ public class BadgeServiceImpl implements BadgeService {
 
         // 첫 해결자와 현재 유저가 동일하다면 뱃지를 부여합니다.
         if (Objects.equals(firstSolverId, userId)) {
-            assignBadgeIfNeeded(userId, "퍼스트 블러드");
+            assignBadgeIfNeeded(userId, BadgeType.FIRST_BLOOD);
         }
     }
 
     @Transactional
-    public void assignBadgeIfNeeded(Long userId, String badgeName) {
+    public void assignBadgeIfNeeded(Long userId, BadgeType badgeType) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
-        Badge badge = badgeRepository.findByName(badgeName)
-                .orElseThrow(() -> new IllegalArgumentException("Badge not found"));
+        Badge badge = badgeRepository.findByName(badgeType.getDisplayName())
+                .orElseThrow(() -> new IllegalArgumentException("Badge not found: " + badgeType.getDisplayName()));
 
         boolean alreadyOwned = userBadgeRepository.existsByUserAndBadge(user, badge);
         if (alreadyOwned) return;


### PR DESCRIPTION
## Summary
Badge와 Category에서 하드코딩된 문자열을 타입 안전한 Enum으로 변경하여 Type Safety를 확보하고 Security 원칙을 준수합니다.

### 주요 변경 사항
- **BadgeType Enum 개선**
  - 한글 `displayName` 필드 추가 (예: BEGINNER("입문자"))
  - `fromDisplayName()` 메서드로 한글 이름 → Enum 변환 지원
  - 11개 뱃지 상수 정의 (BEGINNER, WARGAME_MASTER, HELL_SURVIVOR 등)

- **CategoryType Enum 신규 생성**
  - 5개 카테고리 상수 정의 (WEB, FORENSIC, CRYPTO, BRUTE_FORCE, SOURCE_LEAK)
  - `fromDisplayName()` 메서드로 문자열 → Enum 변환 지원

- **BadgeServiceImpl 리팩토링**
  - 하드코딩된 뱃지 이름 11곳 → `BadgeType.XXX.getDisplayName()` 변경
  - 하드코딩된 카테고리 이름 5곳 → `CategoryType.XXX.getDisplayName()` 변경
  - `assignBadgeIfNeeded()` 시그니처 변경: `String` → `BadgeType`

### 개선 효과
- ✅ **Type Safety**: 컴파일 타임에 오타 검증 가능
- ✅ **Security 원칙 준수**: 하드코딩된 문자열 제거 (No Hardcoding 규칙 준수)
- ✅ **유지보수성**: 뱃지/카테고리 추가 시 Enum만 수정
- ✅ **가독성**: 코드만 봐도 어떤 뱃지/카테고리인지 명확

## Test plan
- [x] 빌드 성공 확인 (`./gradlew build`)
- [ ] Badge 부여 로직 동작 확인
- [ ] Category별 Badge 부여 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)