### PR TITLE
fix: updateUserRole 엔드포인트 권한 체크 추가

### DIFF
--- a/guardians/src/main/java/com/guardians/controller/UserController.java
+++ b/guardians/src/main/java/com/guardians/controller/UserController.java
@@ -112,13 +112,16 @@ public class UserController {
 
 
     @PutMapping("/admin/update-role/{userId}")
-    public ResponseEntity<String> updateUserRole(
+    public ResponseEntity<ResWrapper<?>> updateUserRole(
             @PathVariable Long userId,
-            @RequestBody ReqUpdateUserRoleDto request
+            @RequestBody ReqUpdateUserRoleDto request,
+            HttpSession session
     ) {
+        SessionUtil.requireAdmin(session);
+
         Role role = Role.valueOf(request.getRole());
         userService.updateUserRole(userId, role);
-        return ResponseEntity.ok("권한이 성공적으로 변경되었습니다.");
+        return ResponseEntity.ok(ResWrapper.resSuccess("[관리자] 권한 변경 완료", null));
     }
 
     // 모든 유저 조회


### PR DESCRIPTION
## Summary
- updateUserRole 엔드포인트에 누락된 관리자 권한 체크 추가
- HttpSession 파라미터 및 SessionUtil.requireAdmin() 검증 추가
- ResWrapper 반환 타입으로 응답 형식 통일

## 보안 취약점 수정
기존 코드는 `/api/users/admin/update-role/{userId}` 엔드포인트에 인증/권한 체크가 없어서 누구나 다른 사용자의 권한을 변경할 수 있었음

## Test plan
- [ ] 비로그인 상태에서 권한 변경 API 호출 시 PERMISSION_DENIED 응답 확인
- [ ] 일반 사용자로 권한 변경 API 호출 시 PERMISSION_DENIED 응답 확인
- [ ] 관리자로 권한 변경 API 호출 시 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)