### PR TITLE
perf: N+1 쿼리 문제 해결 - fetch join 추가

### DIFF
--- a/guardians/src/main/java/com/guardians/domain/board/repository/AnswerRepository.java
+++ b/guardians/src/main/java/com/guardians/domain/board/repository/AnswerRepository.java
@@ -14,7 +14,7 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
     Optional<Answer> findByIdWithUser(@Param("id") Long id);
     int countByQuestionId(Long questionId);
 
-    @Query("SELECT a FROM Answer a JOIN FETCH a.user WHERE a.question.id = :questionId ORDER BY a.createdAt ASC")
+    @Query("SELECT a FROM Answer a JOIN FETCH a.user u JOIN FETCH u.userStats WHERE a.question.id = :questionId ORDER BY a.createdAt ASC")
     List<Answer> findAllWithUserByQuestionId(@Param("questionId") Long questionId);
 
     List<Answer> findAllByQuestionIdOrderByCreatedAtAsc(Long questionId);

--- a/guardians/src/main/java/com/guardians/domain/board/repository/BoardRepository.java
+++ b/guardians/src/main/java/com/guardians/domain/board/repository/BoardRepository.java
@@ -20,7 +20,8 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     @Query("SELECT b FROM Board b JOIN FETCH b.user WHERE b.id = :id")
     Optional<Board> findByIdWithUser(@Param("id") Long id);
 
-    List<Board> findAllByUserId(Long userId); // 추가
+    @Query("SELECT b FROM Board b JOIN FETCH b.user WHERE b.user.id = :userId")
+    List<Board> findAllByUserId(@Param("userId") Long userId);
 
     @EntityGraph(attributePaths = {"user"})
     @Query("SELECT b FROM Board b WHERE b.boardType = :boardType AND " +

--- a/guardians/src/main/java/com/guardians/domain/board/repository/CommentRepository.java
+++ b/guardians/src/main/java/com/guardians/domain/board/repository/CommentRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     //댓글 목록 조회용
-    @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.board.id = :boardId")
+    @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.board.id = :boardId ORDER BY c.createdAt ASC")
     List<Comment> findByBoardIdWithUser(@Param("boardId") Long boardId);
     //특정댓글 수정, 삭제용
     @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.id = :commentId")
@@ -21,7 +21,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("SELECT c.board.id AS boardId, COUNT(c.id) AS commentCount " +
             "FROM Comment c GROUP BY c.board.id")
     List<CommentCountRepository> countCommentsByBoard();
-
-    List<Comment> findByBoardIdOrderByCreatedAtAsc(Long boardId);
 
 }

--- a/guardians/src/main/java/com/guardians/domain/wargame/repository/ReviewRepository.java
+++ b/guardians/src/main/java/com/guardians/domain/wargame/repository/ReviewRepository.java
@@ -8,9 +8,8 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-    List<Review> findAllByUserId(Long userId);
-    List<Review> findAllByWargameId(Long wargameId);
-    List<Review> findAllByWargameIdOrderByCreatedAtAsc(Long wargameId);
+    @Query("SELECT r FROM Review r JOIN FETCH r.user WHERE r.wargame.id = :wargameId ORDER BY r.createdAt ASC")
+    List<Review> findAllByWargameIdOrderByCreatedAtAsc(@Param("wargameId") Long wargameId);
 
     @Query("SELECT r FROM Review r JOIN FETCH r.wargame WHERE r.user.id = :userId")
     List<Review> findAllWithWargameByUserId(@Param("userId") Long userId);

--- a/guardians/src/main/java/com/guardians/service/board/CommentServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/board/CommentServiceImpl.java
@@ -56,7 +56,7 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     public List<ResCommentListDto> getCommentsByBoard(Long boardId) {
-        List<Comment> comments = commentRepository.findByBoardIdOrderByCreatedAtAsc(boardId);
+        List<Comment> comments = commentRepository.findByBoardIdWithUser(boardId);
 
         return comments.stream().map(comment -> ResCommentListDto.builder()
                         .commentId(comment.getId())


### PR DESCRIPTION
## 📌 perf: N+1 쿼리 문제 해결 - fetch join 추가

---

## ✨ 주요 변경사항

**Repository별 최적화:**
- **AnswerRepository**: UserStats까지 fetch join 추가
- **CommentRepository**: User fetch join 추가 및 불필요한 메서드 제거
- **BoardRepository**: findAllByUserId에 User fetch join 추가
- **ReviewRepository**: User fetch join 추가 및 불필요한 메서드 정리

---

## 🔍 상세 설명

### 1. AnswerRepository - UserStats N+1 해결
**문제**: AnswerServiceImpl:76에서 `a.getUser().getUserStats().getTier()` 호출 시 N+1 발생

**변경 전**:
```java
@Query("SELECT a FROM Answer a JOIN FETCH a.user WHERE a.question.id = :questionId ORDER BY a.createdAt ASC")
List<Answer> findAllWithUserByQuestionId(@Param("questionId") Long questionId);
```

**변경 후**:
```java
@Query("SELECT a FROM Answer a JOIN FETCH a.user u JOIN FETCH u.userStats WHERE a.question.id = :questionId ORDER BY a.createdAt ASC")
List<Answer> findAllWithUserByQuestionId(@Param("questionId") Long questionId);
```

### 2. CommentRepository - User N+1 해결
**문제**: CommentServiceImpl:59에서 `findByBoardIdOrderByCreatedAtAsc` 사용 시 User N+1 발생

**개선**:
- 기존 `findByBoardIdWithUser`에 ORDER BY 추가
- `findByBoardIdOrderByCreatedAtAsc` 메서드 제거 (중복 제거)
- CommentServiceImpl에서 `findByBoardIdWithUser` 사용

### 3. BoardRepository - User N+1 해결
**문제**: MypageServiceImpl:59에서 `findAllByUserId` 사용 시 User N+1 발생

**변경 전**:
```java
List<Board> findAllByUserId(Long userId);
```

**변경 후**:
```java
@Query("SELECT b FROM Board b JOIN FETCH b.user WHERE b.user.id = :userId")
List<Board> findAllByUserId(@Param("userId") Long userId);
```

### 4. ReviewRepository - User N+1 해결
**문제**: WargameServiceImpl:244에서 `findAllByWargameIdOrderByCreatedAtAsc` 사용 시 User N+1 발생

**개선**:
- User fetch join 추가
- 사용하지 않는 `findAllByUserId`, `findAllByWargameId` 메서드 제거

---

## 📈 성능 개선 효과

| 케이스 | 변경 전 | 변경 후 | 개선율 |
|--------|---------|---------|--------|
| Answer 10개 조회 | 1 + 10 + 10 = 21 queries | 1 query | **95% 감소** |
| Comment 20개 조회 | 1 + 20 = 21 queries | 1 query | **95% 감소** |
| Board 사용자별 조회 | 1 + N queries | 1 query | **N배 개선** |
| Review 조회 | 1 + N queries | 1 query | **N배 개선** |

---

## ✅ 확인 리스트

- [x] **N+1 문제**: 모든 주요 Repository에서 fetch join 적용
- [x] **코드 품질**: 중복 메서드 제거
- [x] **JPA 규칙**: Fetch join 사용으로 성능 최적화
- [x] **관련 규칙**: patterns.md의 "JPA Optimization" 규칙 준수

---

## 🧪 영향 범위

- AnswerServiceImpl.getAnswerListByQuestion()
- CommentServiceImpl.getCommentsByBoard()
- MypageServiceImpl (Board 조회)
- WargameServiceImpl (Review 조회)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)