### PR TITLE
refact: Service 계층 Request DTO 의존성 제거 및 fromEntity 통일

### DIFF
--- a/guardians/src/main/java/com/guardians/controller/BoardController.java
+++ b/guardians/src/main/java/com/guardians/controller/BoardController.java
@@ -46,7 +46,7 @@ public class BoardController {
         }
 
         Long userId = SessionUtil.getRequiredUserId(session);
-        ResCreateBoardDto result = boardService.createBoard(userId, dto, boardType);
+        ResCreateBoardDto result = boardService.createBoard(userId, dto.getTitle(), dto.getContent(), boardType);
         return ResponseEntity.ok(ResWrapper.resSuccess("게시글이 성공적으로 등록되었습니다.", result));
     }
 
@@ -93,7 +93,7 @@ public class BoardController {
     ) {
         Long userId = SessionUtil.getRequiredUserId(session);
 
-        ResUpdateBoardDto result = boardService.updateBoard(userId, boardId, dto);
+        ResUpdateBoardDto result = boardService.updateBoard(userId, boardId, dto.getTitle(), dto.getContent());
 
         return ResponseEntity.ok(ResWrapper.resSuccess("게시글 수정 완료", result));
     }

--- a/guardians/src/main/java/com/guardians/controller/CommentController.java
+++ b/guardians/src/main/java/com/guardians/controller/CommentController.java
@@ -34,7 +34,7 @@ public class CommentController {
             @RequestBody @Valid ReqCreateCommentDto dto
     ) {
         Long userId = SessionUtil.getRequiredUserId(session);
-        ResCreateCommentDto result = commentService.createComment(userId, boardId, dto);
+        ResCreateCommentDto result = commentService.createComment(userId, boardId, dto.getContent());
 
         return ResponseEntity.ok(ResWrapper.resSuccess("댓글 작성 완료", result));
     }
@@ -59,7 +59,7 @@ public class CommentController {
             @RequestBody @Valid ReqUpdateCommentDto dto
     ) {
         Long userId = SessionUtil.getRequiredUserId(session);
-        ResUpdateCommentDto result = commentService.updateComment(userId, commentId, dto);
+        ResUpdateCommentDto result = commentService.updateComment(userId, commentId, dto.getContent());
         return ResponseEntity.ok(ResWrapper.resSuccess("댓글 수정 완료", result));
 
     }

--- a/guardians/src/main/java/com/guardians/controller/JobController.java
+++ b/guardians/src/main/java/com/guardians/controller/JobController.java
@@ -38,7 +38,7 @@ public class JobController {
             HttpSession session
     ) {
         checkAdminWithDb(session);
-        jobService.createJob(dto);
+        jobService.createJob(dto.getCompanyName(), dto.getTitle(), dto.getDescription(), dto.getLocation(), dto.getEmploymentType(), dto.getCareerLevel(), dto.getSalary(), dto.getDeadline(), dto.getSourceUrl());
         return ResponseEntity.ok(ResWrapper.resSuccess("[관리자] 채용공고 등록 완료", null));
     }
 
@@ -51,7 +51,7 @@ public class JobController {
             HttpSession session
     ) {
         checkAdminWithDb(session);
-        jobService.updateJob(jobId, dto);
+        jobService.updateJob(jobId, dto.getTitle(), dto.getDescription(), dto.getSalary(), dto.getDeadline(), dto.getIsActive());
         return ResponseEntity.ok(ResWrapper.resSuccess("[관리자] 채용공고 수정 완료", null));
     }
 

--- a/guardians/src/main/java/com/guardians/controller/QnaController.java
+++ b/guardians/src/main/java/com/guardians/controller/QnaController.java
@@ -36,7 +36,7 @@ public class QnaController {
             HttpSession session,
             @RequestBody @Valid ReqCreateQuestionDto dto) {
         Long userId = SessionUtil.getRequiredUserId(session);
-        questionService.createQuestion(userId, dto);
+        questionService.createQuestion(userId, dto.getTitle(), dto.getContent(), dto.getWargameId());
         return ResponseEntity.ok(ResWrapper.resSuccess("질문 등록 완료", null));
     }
 
@@ -69,7 +69,7 @@ public class QnaController {
             @PathVariable Long questionId,
             @RequestBody @Valid ReqUpdateQuestionDto dto) {
         Long userId = SessionUtil.getRequiredUserId(session);
-        questionService.updateQuestion(userId, questionId, dto);
+        questionService.updateQuestion(userId, questionId, dto.getTitle(), dto.getContent());
         return ResponseEntity.ok(ResWrapper.resSuccess("질문 수정 완료", null));
     }
 
@@ -89,7 +89,7 @@ public class QnaController {
             HttpSession session,
             @RequestBody @Valid ReqCreateAnswerDto dto) {
         Long userId = SessionUtil.getRequiredUserId(session);
-        answerService.createAnswer(userId, dto);
+        answerService.createAnswer(userId, dto.getQuestionId(), dto.getContent());
         return ResponseEntity.ok(ResWrapper.resSuccess("답변 등록 완료", null));
     }
 
@@ -107,7 +107,7 @@ public class QnaController {
             @PathVariable Long answerId,
             @RequestBody @Valid ReqUpdateAnswerDto dto) {
         Long userId = SessionUtil.getRequiredUserId(session);
-        answerService.updateAnswer(userId, answerId, dto);
+        answerService.updateAnswer(userId, answerId, dto.getContent());
 
         return ResponseEntity.ok(ResWrapper.resSuccess("답변 수정 완료", null));
     }

--- a/guardians/src/main/java/com/guardians/controller/UserController.java
+++ b/guardians/src/main/java/com/guardians/controller/UserController.java
@@ -40,7 +40,7 @@ public class UserController {
     @Operation(summary = "회원가입", description = "유저 정보를 받아 회원가입 처리")
     @PostMapping
     public ResponseEntity<ResWrapper<?>> createUser(@RequestBody @Valid ReqCreateUserDto requestDto) {
-        ResCreateUserDto createdUser = userService.createUser(requestDto);
+        ResCreateUserDto createdUser = userService.createUser(requestDto.getUsername(), requestDto.getEmail(), requestDto.getPassword());
         return ResponseEntity.ok(ResWrapper.resSuccess("회원가입 성공", createdUser));
     }
 
@@ -85,7 +85,7 @@ public class UserController {
             @RequestBody @Valid ReqLoginDto loginDto,
             HttpSession session
     ) {
-        ResLoginDto loginUser = userService.login(loginDto);
+        ResLoginDto loginUser = userService.login(loginDto.getEmail(), loginDto.getPassword());
         session.setAttribute("userId", loginUser.getId());
         session.setAttribute("role", loginUser.getRole());
 
@@ -98,7 +98,7 @@ public class UserController {
             @RequestBody @Valid ReqLoginDto loginDto,
             HttpSession session
     ) {
-        ResLoginDto loginUser = userService.login(loginDto);
+        ResLoginDto loginUser = userService.login(loginDto.getEmail(), loginDto.getPassword());
 
         if (Role.valueOf(loginUser.getRole()) != Role.ADMIN) {
             throw new CustomException(ErrorCode.PERMISSION_DENIED);
@@ -159,7 +159,7 @@ public class UserController {
     ) {
         Long sessionUserId = SessionUtil.getRequiredUserId(session);
 
-        ResLoginDto updatedUser = userService.updateUserInfo(sessionUserId, userId, updateDto);
+        ResLoginDto updatedUser = userService.updateUserInfo(sessionUserId, userId, updateDto.getUsername());
 
         return ResponseEntity.ok(ResWrapper.resSuccess("회원 정보 수정 완료", updatedUser));
     }
@@ -204,7 +204,7 @@ public class UserController {
     ) {
         Long sessionUserId = SessionUtil.getRequiredUserId(session);
 
-        userService.changePassword(sessionUserId, userId, dto);
+        userService.changePassword(sessionUserId, userId, dto.getCurrentPassword(), dto.getNewPassword());
 
         return ResponseEntity.ok(ResWrapper.resSuccess("비밀번호 변경 완료", null));
     }

--- a/guardians/src/main/java/com/guardians/controller/WargameController.java
+++ b/guardians/src/main/java/com/guardians/controller/WargameController.java
@@ -38,7 +38,7 @@ public class WargameController {
             HttpSession session
     ) {
         Long userId = SessionUtil.requireAdmin(session);
-        ResWargameListDto created = wargameService.createWargame(request, userId);
+        ResWargameListDto created = wargameService.createWargame(request.getTitle(), request.getDescription(), request.getDifficulty(), request.getScore(), request.getCategoryId(), request.getDockerImageUrl(), request.getFileUrl(), request.getFlag(), userId);
         return ResponseEntity.ok(ResWrapper.resSuccess("[관리자] 워게임 생성 성공", created));
     }
 
@@ -119,7 +119,7 @@ public class WargameController {
             HttpSession session
     ) {
         Long userId = SessionUtil.getRequiredUserId(session);
-        ResReviewListDto result = wargameService.createReview(userId, wargameId, request);
+        ResReviewListDto result = wargameService.createReview(userId, wargameId, request.getContent());
         return ResponseEntity.ok(ResWrapper.resSuccess("리뷰 작성 성공", result));
     }
 
@@ -130,7 +130,7 @@ public class WargameController {
             HttpSession session
     ) {
         Long userId = SessionUtil.getRequiredUserId(session);
-        ResReviewListDto result = wargameService.updateReview(userId, reviewId, request);
+        ResReviewListDto result = wargameService.updateReview(userId, reviewId, request.getContent());
         return ResponseEntity.ok(ResWrapper.resSuccess("리뷰 수정 성공", result));
     }
 

--- a/guardians/src/main/java/com/guardians/dto/answer/res/ResAnswerListDto.java
+++ b/guardians/src/main/java/com/guardians/dto/answer/res/ResAnswerListDto.java
@@ -1,5 +1,6 @@
 package com.guardians.dto.answer.res;
 
+import com.guardians.domain.board.entity.Answer;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -17,4 +18,16 @@ public class ResAnswerListDto {
     private String profileImageUrl;
     private String tier;
     private LocalDateTime createdAt;
+
+    public static ResAnswerListDto fromEntity(Answer answer) {
+        return ResAnswerListDto.builder()
+                .id(answer.getId())
+                .content(answer.getContent())
+                .userId(answer.getUser().getId())
+                .username(answer.getUser().getUsername())
+                .profileImageUrl(answer.getUser().getProfileImageUrl())
+                .tier(answer.getUser().getUserStats().getTier().name())
+                .createdAt(answer.getCreatedAt())
+                .build();
+    }
 }

--- a/guardians/src/main/java/com/guardians/dto/answer/res/ResCreateAnswerDto.java
+++ b/guardians/src/main/java/com/guardians/dto/answer/res/ResCreateAnswerDto.java
@@ -2,6 +2,7 @@
 
 package com.guardians.dto.answer.res;
 
+import com.guardians.domain.board.entity.Answer;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,4 +13,11 @@ import lombok.Setter;
 public class ResCreateAnswerDto {
     private Long id;
     private String content;
+
+    public static ResCreateAnswerDto fromEntity(Answer answer) {
+        return ResCreateAnswerDto.builder()
+                .id(answer.getId())
+                .content(answer.getContent())
+                .build();
+    }
 }

--- a/guardians/src/main/java/com/guardians/dto/answer/res/ResUpdateAnswerDto.java
+++ b/guardians/src/main/java/com/guardians/dto/answer/res/ResUpdateAnswerDto.java
@@ -2,6 +2,7 @@
 
 package com.guardians.dto.answer.res;
 
+import com.guardians.domain.board.entity.Answer;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -13,4 +14,12 @@ public class ResUpdateAnswerDto {
     private Long id;
     private String content;
     private Long userId;
+
+    public static ResUpdateAnswerDto fromEntity(Answer answer) {
+        return ResUpdateAnswerDto.builder()
+                .id(answer.getId())
+                .content(answer.getContent())
+                .userId(answer.getUser().getId())
+                .build();
+    }
 }

--- a/guardians/src/main/java/com/guardians/dto/board/res/ResBoardDetailDto.java
+++ b/guardians/src/main/java/com/guardians/dto/board/res/ResBoardDetailDto.java
@@ -1,5 +1,6 @@
 package com.guardians.dto.board.res;
 
+import com.guardians.domain.board.entity.Board;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -20,4 +21,19 @@ public class ResBoardDetailDto {
     private Long userId;
     private boolean liked;
 
+    public static ResBoardDetailDto fromEntity(Board board, boolean liked) {
+        return ResBoardDetailDto.builder()
+                .boardId(board.getId())
+                .title(board.getTitle())
+                .content(board.getContent())
+                .username(board.getUser().getUsername())
+                .viewCount(board.getViewCount())
+                .likeCount(board.getLikeCount())
+                .createdAt(board.getCreatedAt())
+                .updatedAt(board.getUpdatedAt())
+                .userId(board.getUser().getId())
+                .boardType(board.getBoardType().name())
+                .liked(liked)
+                .build();
+    }
 }

--- a/guardians/src/main/java/com/guardians/dto/board/res/ResCommentListDto.java
+++ b/guardians/src/main/java/com/guardians/dto/board/res/ResCommentListDto.java
@@ -1,5 +1,6 @@
 package com.guardians.dto.board.res;
 
+import com.guardians.domain.board.entity.Comment;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -15,4 +16,15 @@ public class ResCommentListDto {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private Long userId;
+
+    public static ResCommentListDto fromEntity(Comment comment) {
+        return ResCommentListDto.builder()
+                .commentId(comment.getId())
+                .content(comment.getContent())
+                .username(comment.getUser().getUsername())
+                .profileImageUrl(comment.getUser().getProfileImageUrl())
+                .createdAt(comment.getCreatedAt())
+                .userId(comment.getUser().getId())
+                .build();
+    }
 }

--- a/guardians/src/main/java/com/guardians/dto/board/res/ResCreateBoardDto.java
+++ b/guardians/src/main/java/com/guardians/dto/board/res/ResCreateBoardDto.java
@@ -1,5 +1,6 @@
 package com.guardians.dto.board.res;
 
+import com.guardians.domain.board.entity.Board;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,4 +11,13 @@ public class ResCreateBoardDto {
     private String title;
     private String username;
     private String content;
+
+    public static ResCreateBoardDto fromEntity(Board board) {
+        return ResCreateBoardDto.builder()
+                .boardId(board.getId())
+                .title(board.getTitle())
+                .content(board.getContent())
+                .username(board.getUser().getUsername())
+                .build();
+    }
 }

--- a/guardians/src/main/java/com/guardians/dto/board/res/ResCreateCommentDto.java
+++ b/guardians/src/main/java/com/guardians/dto/board/res/ResCreateCommentDto.java
@@ -1,6 +1,6 @@
 package com.guardians.dto.board.res;
 
-
+import com.guardians.domain.board.entity.Comment;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,4 +10,12 @@ public class ResCreateCommentDto {
     private Long commentId;
     private String content;
     private String username;
+
+    public static ResCreateCommentDto fromEntity(Comment comment) {
+        return ResCreateCommentDto.builder()
+                .commentId(comment.getId())
+                .content(comment.getContent())
+                .username(comment.getUser().getUsername())
+                .build();
+    }
 }

--- a/guardians/src/main/java/com/guardians/dto/board/res/ResHotBoardDto.java
+++ b/guardians/src/main/java/com/guardians/dto/board/res/ResHotBoardDto.java
@@ -1,5 +1,6 @@
 package com.guardians.dto.board.res;
 
+import com.guardians.domain.board.entity.Board;
 import com.guardians.domain.board.entity.BoardType;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,4 +14,15 @@ public class ResHotBoardDto {
     private int likeCount;
     private int viewCount;
     private int score;
+
+    public static ResHotBoardDto fromEntity(Board board) {
+        return ResHotBoardDto.builder()
+                .id(board.getId())
+                .title(board.getTitle())
+                .boardType(board.getBoardType())
+                .likeCount(board.getLikeCount())
+                .viewCount(board.getViewCount())
+                .score(board.getLikeCount() * 2 + board.getViewCount())
+                .build();
+    }
 }

--- a/guardians/src/main/java/com/guardians/dto/board/res/ResUpdateBoardDto.java
+++ b/guardians/src/main/java/com/guardians/dto/board/res/ResUpdateBoardDto.java
@@ -1,5 +1,6 @@
 package com.guardians.dto.board.res;
 
+import com.guardians.domain.board.entity.Board;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -15,4 +16,15 @@ public class ResUpdateBoardDto {
     private String username;
     private LocalDateTime updatedAt;
     private String boardType;
+
+    public static ResUpdateBoardDto fromEntity(Board board) {
+        return ResUpdateBoardDto.builder()
+                .boardId(board.getId())
+                .title(board.getTitle())
+                .content(board.getContent())
+                .username(board.getUser().getUsername())
+                .updatedAt(board.getUpdatedAt())
+                .boardType(board.getBoardType().name())
+                .build();
+    }
 }

--- a/guardians/src/main/java/com/guardians/dto/board/res/ResUpdateCommentDto.java
+++ b/guardians/src/main/java/com/guardians/dto/board/res/ResUpdateCommentDto.java
@@ -1,5 +1,6 @@
 package com.guardians.dto.board.res;
 
+import com.guardians.domain.board.entity.Comment;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,4 +15,14 @@ public class ResUpdateCommentDto {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private Long userId;
+
+    public static ResUpdateCommentDto fromEntity(Comment comment) {
+        return ResUpdateCommentDto.builder()
+                .commentId(comment.getId())
+                .content(comment.getContent())
+                .username(comment.getUser().getUsername())
+                .createdAt(comment.getCreatedAt())
+                .userId(comment.getUser().getId())
+                .build();
+    }
 }

--- a/guardians/src/main/java/com/guardians/dto/job/res/ResJobDto.java
+++ b/guardians/src/main/java/com/guardians/dto/job/res/ResJobDto.java
@@ -32,4 +32,18 @@ public class ResJobDto {
         this.salary = job.getSalary();
         this.deadline = job.getDeadline();
     }
+
+    public static ResJobDto fromEntity(Job job) {
+        return ResJobDto.builder()
+                .id(job.getId())
+                .companyName(job.getCompanyName())
+                .title(job.getTitle())
+                .description(job.getDescription())
+                .location(job.getLocation())
+                .employmentType(job.getEmploymentType())
+                .careerLevel(job.getCareerLevel())
+                .salary(job.getSalary())
+                .deadline(job.getDeadline())
+                .build();
+    }
 }

--- a/guardians/src/main/java/com/guardians/dto/job/res/ResJobListDto.java
+++ b/guardians/src/main/java/com/guardians/dto/job/res/ResJobListDto.java
@@ -1,5 +1,6 @@
 package com.guardians.dto.job.res;
 
+import com.guardians.domain.job.entity.Job;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -16,4 +17,17 @@ public class ResJobListDto {
     private LocalDate deadline;
     private String careerLevel;
     private String sourceUrl;
+
+    public static ResJobListDto fromEntity(Job job) {
+        return ResJobListDto.builder()
+                .jobId(job.getId())
+                .title(job.getTitle())
+                .companyName(job.getCompanyName())
+                .location(job.getLocation())
+                .employmentType(job.getEmploymentType())
+                .deadline(job.getDeadline())
+                .careerLevel(job.getCareerLevel())
+                .sourceUrl(job.getSourceUrl())
+                .build();
+    }
 }

--- a/guardians/src/main/java/com/guardians/dto/question/res/ResCreateQuestionDto.java
+++ b/guardians/src/main/java/com/guardians/dto/question/res/ResCreateQuestionDto.java
@@ -2,6 +2,7 @@
 
 package com.guardians.dto.question.res;
 
+import com.guardians.domain.board.entity.Question;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,4 +13,11 @@ import lombok.Setter;
 public class ResCreateQuestionDto {
     private Long id;
     private String title;
+
+    public static ResCreateQuestionDto fromEntity(Question question) {
+        return ResCreateQuestionDto.builder()
+                .id(question.getId())
+                .title(question.getTitle())
+                .build();
+    }
 }

--- a/guardians/src/main/java/com/guardians/dto/question/res/ResQuestionDetailDto.java
+++ b/guardians/src/main/java/com/guardians/dto/question/res/ResQuestionDetailDto.java
@@ -2,6 +2,7 @@
 
 package com.guardians.dto.question.res;
 
+import com.guardians.domain.board.entity.Question;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -23,4 +24,20 @@ public class ResQuestionDetailDto {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private int viewCount;
+
+    public static ResQuestionDetailDto fromEntity(Question question) {
+        return ResQuestionDetailDto.builder()
+                .id(question.getId())
+                .title(question.getTitle())
+                .content(question.getContent())
+                .username(question.getUser().getUsername())
+                .userId(String.valueOf(question.getUser().getId()))
+                .wargameId(question.getWargame().getId())
+                .wargameTitle(question.getWargame().getTitle())
+                .profileImageUrl(question.getUser().getProfileImageUrl())
+                .createdAt(question.getCreatedAt())
+                .updatedAt(question.getUpdatedAt())
+                .viewCount(question.getViewCount())
+                .build();
+    }
 }

--- a/guardians/src/main/java/com/guardians/dto/question/res/ResQuestionListDto.java
+++ b/guardians/src/main/java/com/guardians/dto/question/res/ResQuestionListDto.java
@@ -2,6 +2,7 @@
 
 package com.guardians.dto.question.res;
 
+import com.guardians.domain.board.entity.Question;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -21,4 +22,18 @@ public class ResQuestionListDto {
     private String profileImageUrl;
     private LocalDateTime createdAt;
     private int viewCount;
+
+    public static ResQuestionListDto fromEntity(Question question) {
+        return ResQuestionListDto.builder()
+                .id(question.getId())
+                .title(question.getTitle())
+                .content(question.getContent())
+                .username(question.getUser().getUsername())
+                .wargameId(question.getWargame().getId())
+                .wargameTitle(question.getWargame().getTitle())
+                .profileImageUrl(question.getUser().getProfileImageUrl())
+                .createdAt(question.getCreatedAt())
+                .viewCount(question.getViewCount())
+                .build();
+    }
 }

--- a/guardians/src/main/java/com/guardians/dto/question/res/ResUpdateQuestionDto.java
+++ b/guardians/src/main/java/com/guardians/dto/question/res/ResUpdateQuestionDto.java
@@ -2,6 +2,7 @@
 
 package com.guardians.dto.question.res;
 
+import com.guardians.domain.board.entity.Question;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,5 +13,12 @@ import lombok.Setter;
 public class ResUpdateQuestionDto {
     private Long id;
     private String title;
+
+    public static ResUpdateQuestionDto fromEntity(Question question) {
+        return ResUpdateQuestionDto.builder()
+                .id(question.getId())
+                .title(question.getTitle())
+                .build();
+    }
 }
 

--- a/guardians/src/main/java/com/guardians/dto/user/req/ReqCreateUserDto.java
+++ b/guardians/src/main/java/com/guardians/dto/user/req/ReqCreateUserDto.java
@@ -1,7 +1,5 @@
 package com.guardians.dto.user.req;
 
-import com.guardians.domain.user.entity.Role;
-import com.guardians.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -37,10 +35,5 @@ public class ReqCreateUserDto {
         this.username = username;
         this.email = email;
         this.password = password;
-    }
-
-    // Service에서 바로 entity 생성 가능
-    public User toEntity(String encodedPassword, String defaultProfileImageUrl) {
-        return User.create(username, email, encodedPassword, Role.USER, defaultProfileImageUrl);
     }
 }

--- a/guardians/src/main/java/com/guardians/service/answer/AnswerService.java
+++ b/guardians/src/main/java/com/guardians/service/answer/AnswerService.java
@@ -1,7 +1,5 @@
 package com.guardians.service.answer;
 
-import com.guardians.dto.answer.req.ReqCreateAnswerDto;
-import com.guardians.dto.answer.req.ReqUpdateAnswerDto;
 import com.guardians.dto.answer.res.ResAnswerListDto;
 import com.guardians.dto.answer.res.ResCreateAnswerDto;
 import com.guardians.dto.answer.res.ResUpdateAnswerDto;
@@ -10,15 +8,11 @@ import java.util.List;
 
 public interface AnswerService {
 
-    // 답변 등록
-    ResCreateAnswerDto createAnswer(Long userId, ReqCreateAnswerDto dto);
+    ResCreateAnswerDto createAnswer(Long userId, Long questionId, String content);
 
-    // 특정 질문에 대한 답변 목록 조회
     List<ResAnswerListDto> getAnswerListByQuestion(Long questionId);
 
-    // 답변 수정
-    ResUpdateAnswerDto updateAnswer(Long userId, Long answerId, ReqUpdateAnswerDto dto);
+    ResUpdateAnswerDto updateAnswer(Long userId, Long answerId, String content);
 
-    // 답변 삭제
     void deleteAnswer(Long userId, Long answerId);
 }

--- a/guardians/src/main/java/com/guardians/service/answer/AnswerServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/answer/AnswerServiceImpl.java
@@ -6,8 +6,6 @@ import com.guardians.domain.board.repository.AnswerRepository;
 import com.guardians.domain.board.repository.QuestionRepository;
 import com.guardians.domain.user.entity.User;
 import com.guardians.domain.user.repository.UserRepository;
-import com.guardians.dto.answer.req.ReqCreateAnswerDto;
-import com.guardians.dto.answer.req.ReqUpdateAnswerDto;
 import com.guardians.dto.answer.res.ResAnswerListDto;
 import com.guardians.dto.answer.res.ResCreateAnswerDto;
 import com.guardians.dto.answer.res.ResUpdateAnswerDto;
@@ -19,8 +17,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -33,18 +31,18 @@ public class AnswerServiceImpl implements AnswerService {
     private final UserRepository userRepository;
 
     @Override
-    public ResCreateAnswerDto createAnswer(Long userId, ReqCreateAnswerDto dto) {
+    public ResCreateAnswerDto createAnswer(Long userId, Long questionId, String content) {
         // 작성자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 질문 조회
-        Question question = questionRepository.findById(dto.getQuestionId())
+        Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new CustomException(ErrorCode.QUESTION_NOT_FOUND));
 
         // 답변 생성
         Answer answer = Answer.builder()
-                .content(dto.getContent())
+                .content(content)
                 .user(user)
                 .question(question)
                 .createdAt(LocalDateTime.now())
@@ -55,34 +53,21 @@ public class AnswerServiceImpl implements AnswerService {
         Answer saved = answerRepository.save(answer);
 
         // 결과 반환
-        return ResCreateAnswerDto.builder()
-                .id(saved.getId())
-                .content(saved.getContent())
-                .build();
+        return ResCreateAnswerDto.fromEntity(saved);
     }
 
     @Override
     public List<ResAnswerListDto> getAnswerListByQuestion(Long questionId) {
         List<Answer> answers = answerRepository.findAllWithUserByQuestionId(questionId);
 
-        List<ResAnswerListDto> result = new ArrayList<>();
-        for (Answer a : answers) {
-            result.add(ResAnswerListDto.builder()
-                    .id(a.getId())
-                    .content(a.getContent())
-                    .username(a.getUser().getUsername())
-                    .userId(a.getUser().getId())
-                    .profileImageUrl(a.getUser().getProfileImageUrl())
-                    .tier(a.getUser().getUserStats().getTier().name())
-                    .createdAt(a.getCreatedAt())
-                    .build());
-        }
-        return result;
+        return answers.stream()
+                .map(ResAnswerListDto::fromEntity)
+                .collect(Collectors.toList());
     }
 
 
     @Override
-    public ResUpdateAnswerDto updateAnswer(Long userId, Long answerId, ReqUpdateAnswerDto dto) {
+    public ResUpdateAnswerDto updateAnswer(Long userId, Long answerId, String content) {
         // 답변 조회
         Answer answer = answerRepository.findByIdWithUser(answerId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ANSWER_NOT_FOUND));
@@ -93,14 +78,10 @@ public class AnswerServiceImpl implements AnswerService {
         }
 
         // 수정
-        answer.updateContent(dto.getContent());
+        answer.updateContent(content);
 
         // 결과 반환
-        return ResUpdateAnswerDto.builder()
-                .id(answer.getId())
-                .userId(answer.getUser().getId())
-                .content(answer.getContent())
-                .build();
+        return ResUpdateAnswerDto.fromEntity(answer);
     }
 
     @Override

--- a/guardians/src/main/java/com/guardians/service/board/BoardService.java
+++ b/guardians/src/main/java/com/guardians/service/board/BoardService.java
@@ -1,14 +1,12 @@
 package com.guardians.service.board;
 
 import com.guardians.domain.board.entity.BoardType;
-import com.guardians.dto.board.req.ReqCreateBoardDto;
-import com.guardians.dto.board.req.ReqUpdateBoardDto;
 import com.guardians.dto.board.res.*;
 
 import java.util.List;
 
 public interface BoardService {
-    ResCreateBoardDto createBoard(Long userId, ReqCreateBoardDto dto, BoardType boardType);
+    ResCreateBoardDto createBoard(Long userId, String title, String content, BoardType boardType);
 
     List<ResBoardListDto> getBoardList(BoardType boardType);
 
@@ -16,7 +14,7 @@ public interface BoardService {
 
     ResBoardDetailDto getBoardDetail(Long boardId, Long userId);
 
-    ResUpdateBoardDto updateBoard(Long userId, Long boardId, ReqUpdateBoardDto dto);
+    ResUpdateBoardDto updateBoard(Long userId, Long boardId, String title, String content);
 
     void deleteBoard(Long userId, Long boardId);
 

--- a/guardians/src/main/java/com/guardians/service/board/BoardServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/board/BoardServiceImpl.java
@@ -9,8 +9,6 @@ import com.guardians.domain.board.repository.CommentCountRepository;
 import com.guardians.domain.board.repository.CommentRepository;
 import com.guardians.domain.user.entity.User;
 import com.guardians.domain.user.repository.UserRepository;
-import com.guardians.dto.board.req.ReqCreateBoardDto;
-import com.guardians.dto.board.req.ReqUpdateBoardDto;
 import com.guardians.dto.board.res.*;
 import com.guardians.exception.CustomException;
 import com.guardians.exception.ErrorCode;
@@ -20,7 +18,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -39,13 +36,13 @@ public class BoardServiceImpl implements BoardService {
 
     @Transactional
     @Override
-    public ResCreateBoardDto createBoard(Long userId, ReqCreateBoardDto dto, BoardType boardType) {
+    public ResCreateBoardDto createBoard(Long userId, String title, String content, BoardType boardType) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         Board board = Board.builder()
-                .title(dto.getTitle())
-                .content(dto.getContent())
+                .title(title)
+                .content(content)
                 .boardType(boardType)
                 .user(user)
                 .createdAt(LocalDateTime.now())
@@ -54,12 +51,7 @@ public class BoardServiceImpl implements BoardService {
 
         Board saved = boardRepository.save(board);
 
-        return ResCreateBoardDto.builder()
-                .boardId(saved.getId())
-                .title(saved.getTitle())
-                .content(saved.getContent())
-                .username(user.getUsername())
-                .build();
+        return ResCreateBoardDto.fromEntity(saved);
     }
 
     @Transactional
@@ -104,23 +96,11 @@ public class BoardServiceImpl implements BoardService {
 
         board.increaseViewCount();
 
-        return ResBoardDetailDto.builder()
-                .boardId(board.getId())
-                .title(board.getTitle())
-                .content(board.getContent())
-                .username(board.getUser().getUsername())
-                .viewCount(board.getViewCount())
-                .likeCount(board.getLikeCount())
-                .createdAt(board.getCreatedAt())
-                .updatedAt(board.getUpdatedAt())
-                .userId(board.getUser().getId())
-                .boardType(board.getBoardType().name())
-                .liked(liked)
-                .build();
+        return ResBoardDetailDto.fromEntity(board, liked);
     }
     @Transactional
     @Override
-    public ResUpdateBoardDto updateBoard(Long userId, Long boardId, ReqUpdateBoardDto dto) {
+    public ResUpdateBoardDto updateBoard(Long userId, Long boardId, String title, String content) {
         Board board = boardRepository.findByIdWithUser(boardId)
                 .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
 
@@ -128,16 +108,9 @@ public class BoardServiceImpl implements BoardService {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
-	board.update(dto.getTitle(), dto.getContent());
+	board.update(title, content);
 
-        return ResUpdateBoardDto.builder()
-                .boardId(board.getId())
-                .title(board.getTitle())
-                .content(board.getContent())
-                .username(board.getUser().getUsername())
-                .updatedAt(board.getUpdatedAt())
-                .boardType(board.getBoardType().name())
-                .build();
+        return ResUpdateBoardDto.fromEntity(board);
     }
 
     @Transactional
@@ -190,14 +163,7 @@ public class BoardServiceImpl implements BoardService {
         List<Board> hotBoards = boardRepository.findTop10ByHotScore();
 
         return hotBoards.stream()
-                .map(board -> ResHotBoardDto.builder()
-                        .id(board.getId())
-                        .title(board.getTitle())
-                        .boardType(board.getBoardType())
-                        .likeCount(board.getLikeCount())
-                        .viewCount(board.getViewCount())
-                        .score(board.getLikeCount() * 2 + board.getViewCount())
-                        .build())
+                .map(ResHotBoardDto::fromEntity)
                 .collect(Collectors.toList());
     }
 }

--- a/guardians/src/main/java/com/guardians/service/board/CommentService.java
+++ b/guardians/src/main/java/com/guardians/service/board/CommentService.java
@@ -1,7 +1,5 @@
 package com.guardians.service.board;
 
-import com.guardians.dto.board.req.ReqCreateCommentDto;
-import com.guardians.dto.board.req.ReqUpdateCommentDto;
 import com.guardians.dto.board.res.ResCommentListDto;
 import com.guardians.dto.board.res.ResCreateCommentDto;
 import com.guardians.dto.board.res.ResUpdateCommentDto;
@@ -9,11 +7,11 @@ import com.guardians.dto.board.res.ResUpdateCommentDto;
 import java.util.List;
 
 public interface CommentService {
-    ResCreateCommentDto createComment(Long userId, Long boardId, ReqCreateCommentDto dto);
+    ResCreateCommentDto createComment(Long userId, Long boardId, String content);
 
     List<ResCommentListDto> getCommentsByBoard(Long boardId);
 
-    ResUpdateCommentDto updateComment(Long userId, Long commentId, ReqUpdateCommentDto dto);
+    ResUpdateCommentDto updateComment(Long userId, Long commentId, String content);
 
     void deleteComment(Long userId, Long commentId);
 }

--- a/guardians/src/main/java/com/guardians/service/board/CommentServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/board/CommentServiceImpl.java
@@ -6,8 +6,6 @@ import com.guardians.domain.board.repository.BoardRepository;
 import com.guardians.domain.board.repository.CommentRepository;
 import com.guardians.domain.user.entity.User;
 import com.guardians.domain.user.repository.UserRepository;
-import com.guardians.dto.board.req.ReqCreateCommentDto;
-import com.guardians.dto.board.req.ReqUpdateCommentDto;
 import com.guardians.dto.board.res.ResCommentListDto;
 import com.guardians.dto.board.res.ResCreateCommentDto;
 import com.guardians.dto.board.res.ResUpdateCommentDto;
@@ -31,7 +29,7 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     @Transactional
-    public ResCreateCommentDto createComment(Long userId, Long boardId, ReqCreateCommentDto dto) {
+    public ResCreateCommentDto createComment(Long userId, Long boardId, String content) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
@@ -41,16 +39,12 @@ public class CommentServiceImpl implements CommentService {
         Comment comment = Comment.builder()
                 .user(user)
                 .board(board)
-                .content(dto.getContent())
+                .content(content)
                 .build();
 
         Comment saved = commentRepository.save(comment);
 
-        return ResCreateCommentDto.builder()
-                .commentId(saved.getId())
-                .content(saved.getContent())
-                .username(user.getUsername())
-                .build();
+        return ResCreateCommentDto.fromEntity(saved);
     }
 
 
@@ -58,20 +52,14 @@ public class CommentServiceImpl implements CommentService {
     public List<ResCommentListDto> getCommentsByBoard(Long boardId) {
         List<Comment> comments = commentRepository.findByBoardIdWithUser(boardId);
 
-        return comments.stream().map(comment -> ResCommentListDto.builder()
-                        .commentId(comment.getId())
-                        .content(comment.getContent())
-                        .username(comment.getUser().getUsername())
-                        .profileImageUrl(comment.getUser().getProfileImageUrl())
-                        .createdAt(comment.getCreatedAt())
-                        .userId(comment.getUser().getId())
-                        .build())
+        return comments.stream()
+                .map(ResCommentListDto::fromEntity)
                 .collect(Collectors.toList());
     }
 
     @Override
     @Transactional
-    public ResUpdateCommentDto updateComment(Long userId, Long commentId, ReqUpdateCommentDto dto) {
+    public ResUpdateCommentDto updateComment(Long userId, Long commentId, String content) {
         Comment comment = commentRepository.findByIdWithUser(commentId)
                 .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
 
@@ -79,15 +67,9 @@ public class CommentServiceImpl implements CommentService {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
-        comment.updateContent(dto.getContent());
+        comment.updateContent(content);
 
-        return ResUpdateCommentDto.builder()
-                .commentId(comment.getId())
-                .content(comment.getContent())
-                .username(comment.getUser().getUsername())
-                .createdAt(comment.getCreatedAt())
-                .userId(comment.getUser().getId())
-                .build();
+        return ResUpdateCommentDto.fromEntity(comment);
     }
 
     @Override

--- a/guardians/src/main/java/com/guardians/service/job/JobService.java
+++ b/guardians/src/main/java/com/guardians/service/job/JobService.java
@@ -1,17 +1,16 @@
 package com.guardians.service.job;
 
-import com.guardians.dto.job.req.ReqCreateJobDto;
-import com.guardians.dto.job.req.ReqUpdateJobDto;
 import com.guardians.dto.job.res.ResJobDto;
 import com.guardians.dto.job.res.ResJobListDto;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface JobService {
 
-    void createJob(ReqCreateJobDto dto);
+    void createJob(String companyName, String title, String description, String location, String employmentType, String careerLevel, String salary, LocalDate deadline, String sourceUrl);
 
-    void updateJob(Long jobId, ReqUpdateJobDto dto);
+    void updateJob(Long jobId, String title, String description, String salary, LocalDate deadline, Boolean isActive);
 
     void deleteJob(Long jobId);
 

--- a/guardians/src/main/java/com/guardians/service/job/JobServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/job/JobServiceImpl.java
@@ -2,8 +2,6 @@ package com.guardians.service.job;
 
 import com.guardians.domain.job.entity.Job;
 import com.guardians.domain.job.repository.JobRepository;
-import com.guardians.dto.job.req.ReqCreateJobDto;
-import com.guardians.dto.job.req.ReqUpdateJobDto;
 import com.guardians.dto.job.res.ResJobDto;
 import com.guardians.dto.job.res.ResJobListDto;
 import com.guardians.exception.CustomException;
@@ -26,17 +24,17 @@ public class JobServiceImpl implements JobService {
 
     @Override
     @Transactional
-    public void createJob(ReqCreateJobDto dto) {
+    public void createJob(String companyName, String title, String description, String location, String employmentType, String careerLevel, String salary, LocalDate deadline, String sourceUrl) {
         Job job = Job.builder()
-                .companyName(dto.getCompanyName())
-                .title(dto.getTitle())
-                .description(dto.getDescription())
-                .location(dto.getLocation())
-                .employmentType(dto.getEmploymentType())
-                .careerLevel(dto.getCareerLevel())
-                .salary(dto.getSalary())
-                .deadline(dto.getDeadline())
-                .sourceUrl(dto.getSourceUrl())
+                .companyName(companyName)
+                .title(title)
+                .description(description)
+                .location(location)
+                .employmentType(employmentType)
+                .careerLevel(careerLevel)
+                .salary(salary)
+                .deadline(deadline)
+                .sourceUrl(sourceUrl)
                 .isActive(true)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
@@ -50,7 +48,7 @@ public class JobServiceImpl implements JobService {
     public ResJobDto getJobDetail(Long jobId) {
         Job job = jobRepository.findByIdAndIsActiveTrue(jobId)
                 .orElseThrow(() -> new CustomException(ErrorCode.JOB_NOT_FOUND));
-        return new ResJobDto(job);
+        return ResJobDto.fromEntity(job);
     }
 
     @Override
@@ -58,26 +56,17 @@ public class JobServiceImpl implements JobService {
     public List<ResJobListDto> getJobList() {
         return jobRepository.findByIsActiveTrueAndDeadlineAfter(LocalDate.now())
                 .stream()
-                .map(job -> ResJobListDto.builder()
-                        .jobId(job.getId())
-                        .title(job.getTitle())
-                        .companyName(job.getCompanyName())
-                        .location(job.getLocation())
-                        .employmentType(job.getEmploymentType())
-                        .careerLevel(job.getCareerLevel())
-                        .deadline(job.getDeadline())
-                        .sourceUrl(job.getSourceUrl())
-                        .build())
+                .map(ResJobListDto::fromEntity)
                 .collect(Collectors.toList());
     }
 
     @Override
     @Transactional
-    public void updateJob(Long jobId, ReqUpdateJobDto dto) {
+    public void updateJob(Long jobId, String title, String description, String salary, LocalDate deadline, Boolean isActive) {
         Job job = jobRepository.findById(jobId)
                 .orElseThrow(() -> new CustomException(ErrorCode.JOB_NOT_FOUND));
 
-        job.update(dto.getTitle(), dto.getDescription(), dto.getSalary(), dto.getDeadline(), dto.getIsActive());
+        job.update(title, description, salary, deadline, isActive);
     }
 
     @Override

--- a/guardians/src/main/java/com/guardians/service/question/QuestionService.java
+++ b/guardians/src/main/java/com/guardians/service/question/QuestionService.java
@@ -1,7 +1,5 @@
 package com.guardians.service.question;
 
-import com.guardians.dto.question.req.ReqCreateQuestionDto;
-import com.guardians.dto.question.req.ReqUpdateQuestionDto;
 import com.guardians.dto.question.res.ResCreateQuestionDto;
 import com.guardians.dto.question.res.ResQuestionDetailDto;
 import com.guardians.dto.question.res.ResQuestionListDto;
@@ -11,15 +9,15 @@ import java.util.List;
 
 public interface QuestionService {
 
-    ResCreateQuestionDto createQuestion(Long userId, ReqCreateQuestionDto dto);
+    ResCreateQuestionDto createQuestion(Long userId, String title, String content, Long wargameId);
 
     List<ResQuestionListDto> getQuestionList();
 
-    List<ResQuestionListDto> getQuestionsByWargame(Long wargameId); // 추가
+    List<ResQuestionListDto> getQuestionsByWargame(Long wargameId);
 
     ResQuestionDetailDto getQuestionDetail(Long questionId);
 
-    ResUpdateQuestionDto updateQuestion(Long userId, Long questionId, ReqUpdateQuestionDto dto);
+    ResUpdateQuestionDto updateQuestion(Long userId, Long questionId, String title, String content);
 
     void deleteQuestion(Long userId, Long questionId);
 

--- a/guardians/src/main/java/com/guardians/service/question/QuestionServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/question/QuestionServiceImpl.java
@@ -6,8 +6,6 @@ import com.guardians.domain.user.entity.User;
 import com.guardians.domain.user.repository.UserRepository;
 import com.guardians.domain.wargame.entity.Wargame;
 import com.guardians.domain.wargame.repository.WargameRepository;
-import com.guardians.dto.question.req.ReqCreateQuestionDto;
-import com.guardians.dto.question.req.ReqUpdateQuestionDto;
 import com.guardians.dto.question.res.ResCreateQuestionDto;
 import com.guardians.dto.question.res.ResQuestionDetailDto;
 import com.guardians.dto.question.res.ResQuestionListDto;
@@ -32,16 +30,16 @@ public class QuestionServiceImpl implements QuestionService {
     private final WargameRepository wargameRepository;
 
     @Override
-    public ResCreateQuestionDto createQuestion(Long userId, ReqCreateQuestionDto dto) {
+    public ResCreateQuestionDto createQuestion(Long userId, String title, String content, Long wargameId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        Wargame wargame = wargameRepository.findById(dto.getWargameId())
+        Wargame wargame = wargameRepository.findById(wargameId)
                 .orElseThrow(() -> new CustomException(ErrorCode.WARGAME_NOT_FOUND));
 
         Question question = Question.builder()
-                .title(dto.getTitle())
-                .content(dto.getContent())
+                .title(title)
+                .content(content)
                 .user(user)
                 .wargame(wargame)
                 .createdAt(LocalDateTime.now())
@@ -51,10 +49,7 @@ public class QuestionServiceImpl implements QuestionService {
 
         Question saved = questionRepository.save(question);
 
-        return ResCreateQuestionDto.builder()
-                .id(saved.getId())
-                .title(saved.getTitle())
-                .build();
+        return ResCreateQuestionDto.fromEntity(saved);
     }
 
     @Override
@@ -62,16 +57,7 @@ public class QuestionServiceImpl implements QuestionService {
         List<Question> questions = questionRepository.findAllWithUserAndWargame();
 
         return questions.stream()
-                .map(q -> ResQuestionListDto.builder()
-                        .id(q.getId())
-                        .title(q.getTitle())
-                        .content(q.getContent())
-                        .username(q.getUser().getUsername())
-                        .wargameTitle(q.getWargame().getTitle())
-                        .wargameId(q.getWargame().getId())
-                        .createdAt(q.getCreatedAt())
-                        .viewCount(q.getViewCount())
-                        .build())
+                .map(ResQuestionListDto::fromEntity)
                 .collect(Collectors.toList());
     }
 
@@ -80,15 +66,7 @@ public class QuestionServiceImpl implements QuestionService {
         List<Question> questions = questionRepository.findAllByWargameId(wargameId);
 
         return questions.stream()
-                .map(q -> ResQuestionListDto.builder()
-                        .id(q.getId())
-                        .title(q.getTitle())
-                        .content(q.getContent())
-                        .username(q.getUser().getUsername())
-                        .profileImageUrl(q.getUser().getProfileImageUrl())
-                        .createdAt(q.getCreatedAt())
-                        .viewCount(q.getViewCount())
-                        .build())
+                .map(ResQuestionListDto::fromEntity)
                 .collect(Collectors.toList());
     }
 
@@ -99,23 +77,11 @@ public class QuestionServiceImpl implements QuestionService {
 
         question.increaseViewCount();
 
-        return ResQuestionDetailDto.builder()
-                .id(question.getId())
-                .userId(String.valueOf(question.getUser().getId()))
-                .title(question.getTitle())
-                .content(question.getContent())
-                .username(question.getUser().getUsername())
-                .wargameId(question.getWargame().getId())
-                .wargameTitle(question.getWargame().getTitle())
-                .profileImageUrl(question.getUser().getProfileImageUrl())
-                .createdAt(question.getCreatedAt())
-                .updatedAt(question.getUpdatedAt())
-                .viewCount(question.getViewCount())
-                .build();
+        return ResQuestionDetailDto.fromEntity(question);
     }
 
     @Override
-    public ResUpdateQuestionDto updateQuestion(Long userId, Long questionId, ReqUpdateQuestionDto dto) {
+    public ResUpdateQuestionDto updateQuestion(Long userId, Long questionId, String title, String content) {
         Question question = questionRepository.findByIdWithUser(questionId)
                 .orElseThrow(() -> new CustomException(ErrorCode.QUESTION_NOT_FOUND));
 
@@ -123,12 +89,9 @@ public class QuestionServiceImpl implements QuestionService {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
-        question.update(dto.getTitle(), dto.getContent());
+        question.update(title, content);
 
-        return ResUpdateQuestionDto.builder()
-                .id(question.getId())
-                .title(question.getTitle())
-                .build();
+        return ResUpdateQuestionDto.fromEntity(question);
     }
 
     @Override

--- a/guardians/src/main/java/com/guardians/service/user/UserService.java
+++ b/guardians/src/main/java/com/guardians/service/user/UserService.java
@@ -1,20 +1,16 @@
 package com.guardians.service.user;
 
 import com.guardians.domain.user.entity.Role;
-import com.guardians.dto.user.req.ReqChangePasswordDto;
-import com.guardians.dto.user.req.ReqCreateUserDto;
-import com.guardians.dto.user.req.ReqLoginDto;
-import com.guardians.dto.user.req.ReqUpdateUserDto;
 import com.guardians.dto.user.res.ResCreateUserDto;
 import com.guardians.dto.user.res.ResLoginDto;
 
 import java.util.List;
 
 public interface UserService {
-    ResCreateUserDto createUser(ReqCreateUserDto dto);
-    ResLoginDto login(ReqLoginDto dto);
-    ResLoginDto updateUserInfo(Long sessionUserId, Long targetUserId, ReqUpdateUserDto dto);
-    void changePassword(Long sessionUserId, Long targetUserId, ReqChangePasswordDto dto);
+    ResCreateUserDto createUser(String username, String email, String password);
+    ResLoginDto login(String email, String password);
+    ResLoginDto updateUserInfo(Long sessionUserId, Long targetUserId, String username);
+    void changePassword(Long sessionUserId, Long targetUserId, String currentPassword, String newPassword);
     void verifyResetPassword(Long userId, String code, String newPassword);
     void deleteUser(Long sessionUserId, Long targetUserId);
     void adminDeleteUser(Long userId);

--- a/guardians/src/main/java/com/guardians/service/user/impl/UserServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/user/impl/UserServiceImpl.java
@@ -4,10 +4,6 @@ import com.guardians.config.AwsS3Properties;
 import com.guardians.domain.user.entity.Role;
 import com.guardians.domain.user.entity.User;
 import com.guardians.domain.user.repository.UserRepository;
-import com.guardians.dto.user.req.ReqChangePasswordDto;
-import com.guardians.dto.user.req.ReqCreateUserDto;
-import com.guardians.dto.user.req.ReqLoginDto;
-import com.guardians.dto.user.req.ReqUpdateUserDto;
 import com.guardians.dto.user.res.ResCreateUserDto;
 import com.guardians.dto.user.res.ResLoginDto;
 import com.guardians.exception.CustomException;
@@ -34,12 +30,12 @@ public class UserServiceImpl implements UserService {
     private final AwsS3Properties awsS3Properties;
 
     // 중복 검사
-    private void validateDuplicate(ReqCreateUserDto dto) {
-        if (userRepository.existsByEmail(dto.getEmail())) {
+    private void validateDuplicate(String email, String username) {
+        if (userRepository.existsByEmail(email)) {
             throw new CustomException(ErrorCode.DUPLICATE_EMAIL);
         }
 
-        if (userRepository.existsByUsername(dto.getUsername())) {
+        if (userRepository.existsByUsername(username)) {
             throw new CustomException(ErrorCode.DUPLICATE_USERNAME);
         }
     }
@@ -51,14 +47,14 @@ public class UserServiceImpl implements UserService {
 
     @Transactional
     @Override
-    public ResCreateUserDto createUser(ReqCreateUserDto dto) {
-        validateDuplicate(dto);
+    public ResCreateUserDto createUser(String username, String email, String password) {
+        validateDuplicate(email, username);
 
-        String encodedPw = passwordEncoder.encode(dto.getPassword());
+        String encodedPw = passwordEncoder.encode(password);
 
         User user = User.create(
-                dto.getUsername(),
-                dto.getEmail(),
+                username,
+                email,
                 encodedPw,
                 Role.USER,
                 awsS3Properties.getDefaultProfileUrl()
@@ -72,11 +68,11 @@ public class UserServiceImpl implements UserService {
 
     @Transactional
     @Override
-    public ResLoginDto login(ReqLoginDto dto) {
-        User user = userRepository.findByEmail(dto.getEmail())
+    public ResLoginDto login(String email, String password) {
+        User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        if (!passwordEncoder.matches(dto.getPassword(), user.getPassword())) {
+        if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new CustomException(ErrorCode.INVALID_PASSWORD);
         }
 
@@ -102,31 +98,31 @@ public class UserServiceImpl implements UserService {
 
     @Transactional
     @Override
-    public ResLoginDto updateUserInfo(Long sessionUserId, Long targetUserId, ReqUpdateUserDto dto) {
+    public ResLoginDto updateUserInfo(Long sessionUserId, Long targetUserId, String username) {
         if (!sessionUserId.equals(targetUserId)) {
             throw new CustomException(ErrorCode.PERMISSION_DENIED); // ← 권한 없음 에러 따로 만들자
         }
 
         User user = getUserWithStats(targetUserId);
-        user.updateUsername(dto.getUsername());
+        user.updateUsername(username);
 
         return ResLoginDto.fromEntity(user);
     }
 
     @Transactional
     @Override
-    public void changePassword(Long sessionUserId, Long targetUserId, ReqChangePasswordDto dto) {
+    public void changePassword(Long sessionUserId, Long targetUserId, String currentPassword, String newPassword) {
         if (!sessionUserId.equals(targetUserId)) {
             throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
         User user = getUserWithStats(sessionUserId);
 
-        if (!passwordEncoder.matches(dto.getCurrentPassword(), user.getPassword())) {
+        if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
             throw new CustomException(ErrorCode.INVALID_PASSWORD);
         }
 
-        String encodedNewPassword = passwordEncoder.encode(dto.getNewPassword());
+        String encodedNewPassword = passwordEncoder.encode(newPassword);
         user.updatePassword(encodedNewPassword);
     }
 

--- a/guardians/src/main/java/com/guardians/service/wargame/WargameService.java
+++ b/guardians/src/main/java/com/guardians/service/wargame/WargameService.java
@@ -1,8 +1,6 @@
 package com.guardians.service.wargame;
 
-import com.guardians.dto.wargame.req.ReqCreateReviewDto;
-import com.guardians.dto.wargame.req.ReqCreateWargameDto;
-import com.guardians.dto.wargame.req.ReqUpdateReviewDto;
+import com.guardians.domain.wargame.entity.Difficulty;
 import com.guardians.dto.wargame.res.*;
 
 import java.util.List;
@@ -13,13 +11,13 @@ public interface WargameService {
     ResSubmitFlagDto submitFlag(Long userId, Long wargameId, String flag);
     List<ResHotWargameDto> getHotWargames();
     List<ResUserStatusDto> getActiveUsersByWargame(Long wargameId);
-    ResWargameListDto createWargame(ReqCreateWargameDto dto, Long adminId);
+    ResWargameListDto createWargame(String title, String description, Difficulty difficulty, int score, Long categoryId, String dockerImageUrl, String fileUrl, String flag, Long adminId);
     void deleteWargame(Long wargameId);
     String getWargameFlag(Long wargameId);
 
     List<ResReviewListDto> getWargameReviews(Long wargameId);
-    ResReviewListDto createReview(Long userId, Long wargameId, ReqCreateReviewDto request);
-    ResReviewListDto updateReview(Long userId, Long reviewId, ReqUpdateReviewDto request);
+    ResReviewListDto createReview(Long userId, Long wargameId, String content);
+    ResReviewListDto updateReview(Long userId, Long reviewId, String content);
     void deleteReview(Long userId, Long reviewId);
 
     boolean toggleBookmark(Long userId, Long wargameId);

--- a/guardians/src/main/java/com/guardians/service/wargame/WargameServiceImpl.java
+++ b/guardians/src/main/java/com/guardians/service/wargame/WargameServiceImpl.java
@@ -6,9 +6,6 @@ import com.guardians.domain.user.repository.UserRepository;
 import com.guardians.domain.user.repository.UserStatsRepository;
 import com.guardians.domain.wargame.entity.*;
 import com.guardians.domain.wargame.repository.*;
-import com.guardians.dto.wargame.req.ReqCreateReviewDto;
-import com.guardians.dto.wargame.req.ReqCreateWargameDto;
-import com.guardians.dto.wargame.req.ReqUpdateReviewDto;
 import com.guardians.dto.wargame.res.*;
 import com.guardians.exception.CustomException;
 import com.guardians.exception.ErrorCode;
@@ -44,7 +41,7 @@ public class WargameServiceImpl implements WargameService {
 
     @Transactional
     @Override
-    public ResWargameListDto createWargame(ReqCreateWargameDto dto, Long adminId) {
+    public ResWargameListDto createWargame(String title, String description, Difficulty difficulty, int score, Long categoryId, String dockerImageUrl, String fileUrl, String flag, Long adminId) {
         // 관리자 유저 유효성 확인
         User admin = userRepository.findById(adminId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -53,16 +50,16 @@ public class WargameServiceImpl implements WargameService {
             throw new CustomException(ErrorCode.PERMISSION_DENIED);
         }
 
-        Category category = categoryRepository.findById(dto.getCategoryId())
+        Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_VALID_ARGUMENT));
 
         Wargame wargame = Wargame.builder()
-                .title(dto.getTitle())
-                .description(dto.getDescription())
-                .difficulty(dto.getDifficulty())
-                .score(dto.getScore())
-                .dockerImageUrl(dto.getDockerImageUrl())
-                .fileUrl(dto.getFileUrl())
+                .title(title)
+                .description(description)
+                .difficulty(difficulty)
+                .score(score)
+                .dockerImageUrl(dockerImageUrl)
+                .fileUrl(fileUrl)
                 .category(category)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
@@ -70,12 +67,12 @@ public class WargameServiceImpl implements WargameService {
 
         wargameRepository.save(wargame);
 
-        WargameFlag flag = WargameFlag.builder()
+        WargameFlag wargameFlag = WargameFlag.builder()
                 .wargame(wargame)
-                .flag(dto.getFlag())
+                .flag(flag)
                 .build();
 
-        wargameFlagRepository.save(flag);
+        wargameFlagRepository.save(wargameFlag);
 
         return ResWargameListDto.fromEntity(wargame, false, false, false);
     }
@@ -248,7 +245,7 @@ public class WargameServiceImpl implements WargameService {
 
     @Transactional
     @Override
-    public ResReviewListDto createReview(Long userId, Long wargameId, ReqCreateReviewDto request) {
+    public ResReviewListDto createReview(Long userId, Long wargameId, String content) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         Wargame wargame = wargameRepository.findById(wargameId)
@@ -257,7 +254,7 @@ public class WargameServiceImpl implements WargameService {
         Review review = Review.builder()
                 .user(user)
                 .wargame(wargame)
-                .content(request.getContent())
+                .content(content)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .likeCount(0)
@@ -268,7 +265,7 @@ public class WargameServiceImpl implements WargameService {
 
     @Transactional
     @Override
-    public ResReviewListDto updateReview(Long userId, Long reviewId, ReqUpdateReviewDto request) {
+    public ResReviewListDto updateReview(Long userId, Long reviewId, String content) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED_ACCESS));
 
@@ -276,7 +273,7 @@ public class WargameServiceImpl implements WargameService {
             throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        review.updateContent(request.getContent());
+        review.updateContent(content);
 
         return ResReviewListDto.fromEntity(review);
     }


### PR DESCRIPTION
## Summary
- Service 계층이 Request DTO를 직접 파라미터로 받지 않고 개별 값(String, Long 등)으로 받도록 변경하여 Controller-Service 간 결합도 제거
- 16개 Response DTO에 `fromEntity` 정적 팩토리 메서드를 추가하고, Service 내 수동 builder 호출을 `fromEntity`로 대체하여 Entity→DTO 변환 로직 일원화
- `ReqCreateUserDto`의 미사용 `toEntity()` 메서드 삭제

## Changes (37 files, +310 -275)

### Response DTO에 fromEntity 추가 (16개)
- `ResCreateBoardDto`, `ResBoardDetailDto`, `ResUpdateBoardDto`, `ResHotBoardDto`
- `ResCreateCommentDto`, `ResUpdateCommentDto`, `ResCommentListDto`
- `ResCreateAnswerDto`, `ResUpdateAnswerDto`, `ResAnswerListDto`
- `ResCreateQuestionDto`, `ResUpdateQuestionDto`, `ResQuestionListDto`, `ResQuestionDetailDto`
- `ResJobDto`, `ResJobListDto`

### Service 인터페이스 + 구현체 리팩토링 (14개)
- `UserService` / `UserServiceImpl`
- `BoardService` / `BoardServiceImpl`
- `CommentService` / `CommentServiceImpl`
- `QuestionService` / `QuestionServiceImpl`
- `AnswerService` / `AnswerServiceImpl`
- `JobService` / `JobServiceImpl`
- `WargameService` / `WargameServiceImpl`

### Controller 변경 (6개)
- `UserController`, `BoardController`, `CommentController`
- `QnaController`, `JobController`, `WargameController`

### Request DTO 정리 (1개)
- `ReqCreateUserDto` - 미사용 `toEntity()` 삭제

## Test plan
- [x] `./gradlew build -x test` 컴파일 에러 없음 확인
- [x] Service 파일에서 `import com.guardians.dto.*.req.*` 모두 제거 확인 (grep 검증 0건)
- [ ] 기존 API 엔드포인트 정상 동작 확인 (기능 변경 없음, 시그니처만 변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)