### PR TITLE
fix: 테스트 코드 Service 시그니처 리팩토링 반영

### DIFF
--- a/guardians/src/test/java/com/guardians/controller/CommentControllerTest.java
+++ b/guardians/src/test/java/com/guardians/controller/CommentControllerTest.java
@@ -8,7 +8,6 @@ import com.guardians.dto.board.res.ResCommentListDto;
 import com.guardians.service.board.CommentService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -24,7 +23,6 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -67,9 +65,7 @@ class CommentControllerTest {
                 .andExpect(status().isOk())
                 .andDo(print());
 
-        ArgumentCaptor<ReqCreateCommentDto> dtoCaptor = ArgumentCaptor.forClass(ReqCreateCommentDto.class);
-        verify(commentService).createComment(eq(userId), eq(boardId), dtoCaptor.capture());
-        assertEquals(request.getContent(), dtoCaptor.getValue().getContent());
+        verify(commentService).createComment(eq(userId), eq(boardId), eq("테스트 댓글 내용"));
     }
 
     @Test
@@ -123,9 +119,7 @@ class CommentControllerTest {
                 .andExpect(status().isOk())
                 .andDo(print());
 
-        ArgumentCaptor<ReqUpdateCommentDto> dtoCaptor = ArgumentCaptor.forClass(ReqUpdateCommentDto.class);
-        verify(commentService).updateComment(eq(userId), eq(commentId), dtoCaptor.capture());
-        assertEquals(request.getContent(), dtoCaptor.getValue().getContent());
+        verify(commentService).updateComment(eq(userId), eq(commentId), eq("수정된 댓글 내용"));
     }
 
     @Test

--- a/guardians/src/test/java/com/guardians/controller/JobControllerTest.java
+++ b/guardians/src/test/java/com/guardians/controller/JobControllerTest.java
@@ -2,6 +2,7 @@ package com.guardians.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.guardians.domain.job.entity.Job;
+import com.guardians.domain.user.entity.Role;
 import com.guardians.domain.user.entity.User;
 import com.guardians.dto.job.req.ReqCreateJobDto;
 import com.guardians.dto.job.req.ReqUpdateJobDto;
@@ -22,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -52,7 +54,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
                         .id(1L)
                         .username("admin")
                         .email("admin@example.com")
-                        .role("ADMIN")
+                        .role(Role.ADMIN)
                         .profileImageUrl("http://example.com/profile.jpg")
                         .build()
         ));
@@ -82,7 +84,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.message").value("[관리자] 채용공고 등록 완료"));
 
-        verify(jobService).createJob(any());
+        verify(jobService).createJob(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), any(LocalDate.class), anyString());
     }
 
     @Test
@@ -105,7 +107,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.message").value("[관리자] 채용공고 수정 완료"));
 
-        verify(jobService).updateJob(eq(1L), any());
+        verify(jobService).updateJob(eq(1L), anyString(), anyString(), anyString(), any(LocalDate.class), any(Boolean.class));
     }
 
     @Test

--- a/guardians/src/test/java/com/guardians/controller/QnaControllerTest.java
+++ b/guardians/src/test/java/com/guardians/controller/QnaControllerTest.java
@@ -9,7 +9,6 @@ import com.guardians.service.answer.AnswerService;
 import com.guardians.service.question.QuestionService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -21,7 +20,7 @@ import org.springframework.session.data.redis.config.annotation.web.http.RedisHt
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -67,13 +66,7 @@ class QnaControllerTest {
                 .andExpect(status().isOk())
                 .andDo(print());
 
-        ArgumentCaptor<Long> userIdCaptor = ArgumentCaptor.forClass(Long.class);
-        ArgumentCaptor<ReqCreateQuestionDto> requestDtoCaptor = ArgumentCaptor.forClass(ReqCreateQuestionDto.class);
-
-        verify(questionService).createQuestion(userIdCaptor.capture(), requestDtoCaptor.capture());
-
-        assertEquals(1L, userIdCaptor.getValue());
-        assertEquals("테스트 질문 제목", requestDtoCaptor.getValue().getTitle());
+        verify(questionService).createQuestion(eq(1L), eq("테스트 질문 제목"), eq("테스트 질문 내용입니다."), eq(1L));
     }
 
     @Test
@@ -93,15 +86,7 @@ class QnaControllerTest {
                 .andExpect(status().isOk())
                 .andDo(print());
 
-        ArgumentCaptor<Long> userIdCaptor = ArgumentCaptor.forClass(Long.class);
-        ArgumentCaptor<Long> questionIdCaptor = ArgumentCaptor.forClass(Long.class);
-        ArgumentCaptor<ReqUpdateQuestionDto> requestDtoCaptor = ArgumentCaptor.forClass(ReqUpdateQuestionDto.class);
-
-        verify(questionService).updateQuestion(userIdCaptor.capture(), questionIdCaptor.capture(), requestDtoCaptor.capture());
-
-        assertEquals(1L, userIdCaptor.getValue());
-        assertEquals(questionId, questionIdCaptor.getValue());
-        assertEquals("수정된 제목", requestDtoCaptor.getValue().getTitle());
+        verify(questionService).updateQuestion(eq(1L), eq(questionId), eq("수정된 제목"), eq("수정된 내용"));
     }
 
     @Test

--- a/guardians/src/test/java/com/guardians/controller/UserControllerTest.java
+++ b/guardians/src/test/java/com/guardians/controller/UserControllerTest.java
@@ -80,7 +80,7 @@ class UserControllerTest {
                 .createdAt(null)
                 .build();
 
-        given(userService.createUser(any(ReqCreateUserDto.class))).willReturn(expectedResponse);
+        given(userService.createUser(anyString(), anyString(), anyString())).willReturn(expectedResponse);
 
         // When & Then
         mockMvc.perform(post("/api/users") // POST 요청
@@ -93,7 +93,7 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.result.data.username").value("tester")) // username 필드 검증 추가
                 .andDo(print()); // 요청/응답 내용 로깅 (디버깅 시 유용)
 
-        verify(userService).createUser(any(ReqCreateUserDto.class));
+        verify(userService).createUser(anyString(), anyString(), anyString());
     }
 
     @Test
@@ -232,7 +232,7 @@ class UserControllerTest {
 
         MockHttpSession mockSession = new MockHttpSession();
 
-        given(userService.login(any(ReqLoginDto.class))).willReturn(expectedResponse);
+        given(userService.login(anyString(), anyString())).willReturn(expectedResponse);
 
         // When & Then
         mockMvc.perform(post("/api/users/login")
@@ -252,7 +252,7 @@ class UserControllerTest {
                 .andExpect(request().sessionAttribute("role", "USER"))
                 .andDo(print());
 
-        verify(userService).login(any(ReqLoginDto.class));
+        verify(userService).login(anyString(), anyString());
     }
 
     @Test
@@ -271,7 +271,7 @@ class UserControllerTest {
                 .build();
         MockHttpSession mockSession = new MockHttpSession();
 
-        given(userService.login(any(ReqLoginDto.class))).willReturn(adminResponse);
+        given(userService.login(anyString(), anyString())).willReturn(adminResponse);
 
         // When & Then
         mockMvc.perform(post("/api/users/admin/login")
@@ -289,7 +289,7 @@ class UserControllerTest {
                 .andExpect(request().sessionAttribute("role", "ADMIN"))
                 .andDo(print());
 
-        verify(userService).login(any(ReqLoginDto.class));
+        verify(userService).login(anyString(), anyString());
     }
 
 
@@ -308,7 +308,7 @@ class UserControllerTest {
                 .build();
         MockHttpSession mockSession = new MockHttpSession();
 
-        given(userService.login(any(ReqLoginDto.class))).willReturn(userResponse);
+        given(userService.login(anyString(), anyString())).willReturn(userResponse);
         // 컨트롤러에서 CustomException(ErrorCode.PERMISSION_DENIED) 발생 예상
 
         // When & Then
@@ -385,7 +385,7 @@ class UserControllerTest {
                 .build();
 
         // userService.updateUserInfo의 반환 타입이 ResLoginDto라고 가정
-        given(userService.updateUserInfo(eq(userId), eq(userId), any(ReqUpdateUserDto.class))).willReturn(updatedUserResponse);
+        given(userService.updateUserInfo(eq(userId), eq(userId), anyString())).willReturn(updatedUserResponse);
 
         // When & Then
         mockMvc.perform(patch("/api/users/{userId}/update", userId)
@@ -402,7 +402,7 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.result.data.lastLoginAt").value(mockTime.format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"))))
                 .andDo(print());
 
-        verify(userService).updateUserInfo(eq(userId), eq(userId), any(ReqUpdateUserDto.class));
+        verify(userService).updateUserInfo(eq(userId), eq(userId), anyString());
     }
 
     // --- 내 정보 조회 테스트 (getCurrentUser) ---


### PR DESCRIPTION
## Summary
- Service 계층 DTO 의존성 제거 리팩토링(#66)에 맞춰 테스트 코드의 mock/verify 호출을 개별 파라미터 방식으로 수정
- `UserControllerTest`: `createUser`, `login`, `updateUserInfo` mock/verify 시그니처 변경
- `CommentControllerTest`: `ArgumentCaptor<ReqCreateCommentDto/ReqUpdateCommentDto>` 제거 → `eq()` 직접 검증
- `QnaControllerTest`: `ArgumentCaptor<ReqCreateQuestionDto/ReqUpdateQuestionDto>` 제거 → `eq()` 직접 검증
- `JobControllerTest`: `createJob(any())` → 9개 개별 파라미터, `updateJob(eq, any())` → 6개 개별 파라미터, `Role.ADMIN` enum 수정

## Test plan
- [x] `./gradlew compileTestJava` 컴파일 성공 확인
- [ ] `@ExtendWith(MockitoExtension)` 기반 테스트 (UserController, Wargame, Dashboard) PASS 확인
- [ ] `@WebMvcTest` 기반 테스트는 `${VAULT_URI}` 환경변수 설정 후 확인 필요 (기존 이슈)

🤖 Generated with [Claude Code](https://claude.com/claude-code)