### PR TITLE
refactor: toggleBookmark/toggleLike WargameFacade로 이동

### DIFF
--- a/guardians/src/main/java/com/guardians/application/wargame/WargameFacade.java
+++ b/guardians/src/main/java/com/guardians/application/wargame/WargameFacade.java
@@ -182,7 +182,19 @@ public class WargameFacade {
         Wargame wargame = wargamePort.findById(wargameId)
                 .orElseThrow(() -> new CustomException(ErrorCode.WARGAME_NOT_FOUND));
 
-        return wargameDomainService.toggleBookmark(user, wargame);
+        return bookmarkPort.findByUserAndWargame(user, wargame)
+                .map(existing -> {
+                    bookmarkPort.delete(existing);
+                    return false;
+                })
+                .orElseGet(() -> {
+                    bookmarkPort.save(Bookmark.builder()
+                            .user(user)
+                            .wargame(wargame)
+                            .createdAt(LocalDateTime.now())
+                            .build());
+                    return true;
+                });
     }
 
     @Transactional
@@ -194,7 +206,21 @@ public class WargameFacade {
         Wargame wargame = wargamePort.findById(wargameId)
                 .orElseThrow(() -> new CustomException(ErrorCode.WARGAME_NOT_FOUND));
 
-        return wargameDomainService.toggleLike(user, wargame);
+        return wargameLikePort.findByUserAndWargame(user, wargame)
+                .map(existing -> {
+                    wargameLikePort.delete(existing);
+                    wargame.decreaseLikeCount();
+                    return false;
+                })
+                .orElseGet(() -> {
+                    wargameLikePort.save(WargameLike.builder()
+                            .user(user)
+                            .wargame(wargame)
+                            .createdAt(LocalDateTime.now())
+                            .build());
+                    wargame.increaseLikeCount();
+                    return true;
+                });
     }
 
     public List<ResReviewListDto> getWargameReviews(Long wargameId) {

--- a/guardians/src/main/java/com/guardians/domain/wargame/service/WargameDomainService.java
+++ b/guardians/src/main/java/com/guardians/domain/wargame/service/WargameDomainService.java
@@ -1,65 +1,10 @@
 package com.guardians.domain.wargame.service;
 
-import com.guardians.domain.wargame.entity.Bookmark;
-import com.guardians.domain.wargame.entity.WargameLike;
-import com.guardians.domain.wargame.port.BookmarkPort;
-import com.guardians.domain.wargame.port.WargameLikePort;
-import com.guardians.domain.user.entity.User;
-import com.guardians.domain.wargame.entity.Wargame;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
-import java.util.Optional;
-
 @Component
-@RequiredArgsConstructor
 public class WargameDomainService {
 
-    private final BookmarkPort bookmarkPort;
-    private final WargameLikePort wargameLikePort;
-
-    /**
-     * 북마크 토글: 존재하면 삭제(false), 없으면 생성(true)
-     */
-    public boolean toggleBookmark(User user, Wargame wargame) {
-        Optional<Bookmark> existing = bookmarkPort.findByUserAndWargame(user, wargame);
-        if (existing.isPresent()) {
-            bookmarkPort.delete(existing.get());
-            return false;
-        } else {
-            bookmarkPort.save(Bookmark.builder()
-                    .user(user)
-                    .wargame(wargame)
-                    .createdAt(LocalDateTime.now())
-                    .build());
-            return true;
-        }
-    }
-
-    /**
-     * 좋아요 토글: 존재하면 삭제·likeCount 감소(false), 없으면 생성·likeCount 증가(true)
-     */
-    public boolean toggleLike(User user, Wargame wargame) {
-        Optional<WargameLike> existing = wargameLikePort.findByUserAndWargame(user, wargame);
-        if (existing.isPresent()) {
-            wargameLikePort.delete(existing.get());
-            wargame.decreaseLikeCount();
-            return false;
-        } else {
-            wargameLikePort.save(WargameLike.builder()
-                    .user(user)
-                    .wargame(wargame)
-                    .createdAt(LocalDateTime.now())
-                    .build());
-            wargame.increaseLikeCount();
-            return true;
-        }
-    }
-
-    /**
-     * 플래그 정답 판별
-     */
     public boolean isCorrectFlag(String storedFlag, String submittedFlag) {
         return storedFlag.equals(submittedFlag);
     }


### PR DESCRIPTION
## Background
WargameDomainService가 Port를 직접 호출하고 있어 Domain Service의 역할을 벗어난 상태였습니다. Domain Service는 순수 비즈니스 로직만 담아야 하며, DB 접근이 필요한 로직은 Facade에 있어야 합니다.

## Summary
toggleBookmark, toggleLike 메서드를 WargameDomainService에서 WargameFacade로 이동했습니다. WargameDomainService는 isCorrectFlag 순수 로직만 유지합니다.

## Changes
- WargameDomainService에서 BookmarkPort, WargameLikePort 의존성 제거
- toggleBookmark, toggleLike 로직을 WargameFacade로 이식하여 Port 직접 호출
- WargameDomainService는 순수 Java 로직(isCorrectFlag)만 보유

## Checklist
- [x] 빌드 확인 (BUILD SUCCESSFUL)
- [x] 기존 동작 유지