### PR TITLE
fix: REST API용 Security 설정 개선

### DIFF
--- a/guardians/src/main/java/com/guardians/config/SecurityConfig.java
+++ b/guardians/src/main/java/com/guardians/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.guardians.config;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -59,7 +60,12 @@ public class SecurityConfig {
                         .requestMatchers("/api/admin/**").authenticated()
                         .anyRequest().authenticated()
                 )
-                .httpBasic(Customizer.withDefaults())
+                .httpBasic(basic -> basic.disable())
+                .formLogin(form -> form.disable())
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((request, response, authException) ->
+                                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized"))
+                )
                 .build();
     }
 }


### PR DESCRIPTION
## Background

프론트엔드에서 인증이 필요한 API를 호출할 때 브라우저에 로그인 팝업(HTTP Basic Auth 다이얼로그)이 뜨는 문제가 있었다. Spring Security의 기본 설정인 `httpBasic`이 활성화되어 있어 401 응답 시 브라우저가 자동으로 자격증명 입력창을 표시하고, `formLogin`도 활성화되어 미인증 요청을 `/login`으로 리다이렉트하는 동작이 원인이었다. REST API 서버는 이런 브라우저 기반 인증 흐름 대신 401 JSON 응답을 반환해야 한다.

## Summary

`SecurityConfig`에서 REST API에 적합하지 않은 인증 방식을 비활성화하고, 미인증 요청에 대해 401 상태 코드를 반환하도록 `authenticationEntryPoint`를 명시적으로 설정했다.

## Changes

`httpBasic`을 비활성화하여 브라우저 기본 로그인 팝업이 뜨지 않도록 했다. `formLogin`도 비활성화하여 미인증 요청이 `/login`으로 리다이렉트되지 않게 했다. `exceptionHandling`에 커스텀 `authenticationEntryPoint`를 등록하여 인증되지 않은 모든 요청에 HTTP 401 응답을 일관되게 반환한다.

## Checklist
- [ ] 로그인 없이 보호된 API 호출 시 브라우저 팝업 없이 401 응답 확인
- [ ] 로그인 후 보호된 API 정상 호출 확인
