### PR TITLE
refactor: 헥사고날 아키텍처 레이어 위반 일괄 수정

### DIFF
--- a/guardians/src/main/java/com/guardians/application/auth/AuthFacade.java
+++ b/guardians/src/main/java/com/guardians/application/auth/AuthFacade.java
@@ -1,28 +1,24 @@
 package com.guardians.application.auth;
 
-import com.guardians.service.auth.EmailVerificationService;
+import com.guardians.domain.user.port.EmailVerificationPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-/**
- * 인증 관련 유스케이스 조율 (이메일 인증코드 발송/검증)
- * EmailVerificationService는 @Service 직접 구현체이므로 그대로 위임한다.
- */
 @Service
 @RequiredArgsConstructor
 public class AuthFacade {
 
-    private final EmailVerificationService emailVerificationService;
+    private final EmailVerificationPort emailVerificationPort;
 
     public void sendVerificationCode(String email, String templatePath) {
-        emailVerificationService.sendVerificationCode(email, templatePath);
+        emailVerificationPort.sendVerificationCode(email, templatePath);
     }
 
     public void sendVerificationCode(String email) {
-        emailVerificationService.sendVerificationCode(email);
+        emailVerificationPort.sendVerificationCode(email, "mail/signup-verification.html");
     }
 
     public boolean verifyCode(String email, String code) {
-        return emailVerificationService.verifyCode(email, code);
+        return emailVerificationPort.verifyCode(email, code);
     }
 }

--- a/guardians/src/main/java/com/guardians/application/board/QnaFacade.java
+++ b/guardians/src/main/java/com/guardians/application/board/QnaFacade.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class QnaFacade {
 
     private final QuestionPort questionPort;
@@ -35,6 +35,7 @@ public class QnaFacade {
     private final UserPort userPort;
     private final WargamePort wargamePort;
 
+    @Transactional
     public ResCreateQuestionDto createQuestion(Long userId, String title, String content, Long wargameId) {
         User user = userPort.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -74,6 +75,7 @@ public class QnaFacade {
         return ResQuestionDetailDto.fromEntity(question);
     }
 
+    @Transactional
     public ResUpdateQuestionDto updateQuestion(Long userId, Long questionId, String title, String content) {
         Question question = questionPort.findByIdWithUser(questionId)
                 .orElseThrow(() -> new CustomException(ErrorCode.QUESTION_NOT_FOUND));
@@ -86,6 +88,7 @@ public class QnaFacade {
         return ResUpdateQuestionDto.fromEntity(question);
     }
 
+    @Transactional
     public void deleteQuestion(Long userId, Long questionId) {
         Question question = questionPort.findByIdWithUser(questionId)
                 .orElseThrow(() -> new CustomException(ErrorCode.QUESTION_NOT_FOUND));
@@ -97,12 +100,14 @@ public class QnaFacade {
         questionPort.delete(question);
     }
 
+    @Transactional
     public void increaseViewCount(Long questionId) {
         Question question = questionPort.findById(questionId)
                 .orElseThrow(() -> new CustomException(ErrorCode.QUESTION_NOT_FOUND));
         question.increaseViewCount();
     }
 
+    @Transactional
     public ResCreateAnswerDto createAnswer(Long userId, Long questionId, String content) {
         User user = userPort.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -127,6 +132,7 @@ public class QnaFacade {
                 .collect(Collectors.toList());
     }
 
+    @Transactional
     public ResUpdateAnswerDto updateAnswer(Long userId, Long answerId, String content) {
         Answer answer = answerPort.findByIdWithUser(answerId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ANSWER_NOT_FOUND));
@@ -139,6 +145,7 @@ public class QnaFacade {
         return ResUpdateAnswerDto.fromEntity(answer);
     }
 
+    @Transactional
     public void deleteAnswer(Long userId, Long answerId) {
         Answer answer = answerPort.findByIdWithUser(answerId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ANSWER_NOT_FOUND));

--- a/guardians/src/main/java/com/guardians/application/job/JobFacade.java
+++ b/guardians/src/main/java/com/guardians/application/job/JobFacade.java
@@ -2,6 +2,8 @@ package com.guardians.application.job;
 
 import com.guardians.domain.job.entity.Job;
 import com.guardians.domain.job.port.JobPort;
+import com.guardians.domain.user.entity.User;
+import com.guardians.domain.user.port.UserPort;
 import com.guardians.dto.job.res.ResJobDto;
 import com.guardians.dto.job.res.ResJobListDto;
 import com.guardians.exception.CustomException;
@@ -21,6 +23,15 @@ import java.util.stream.Collectors;
 public class JobFacade {
 
     private final JobPort jobPort;
+    private final UserPort userPort;
+
+    public void verifyAdmin(Long userId) {
+        User user = userPort.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (!user.isAdmin()) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+    }
 
     @Transactional
     public void createJob(String companyName, String title, String description, String location,

--- a/guardians/src/main/java/com/guardians/application/user/UserFacade.java
+++ b/guardians/src/main/java/com/guardians/application/user/UserFacade.java
@@ -1,21 +1,23 @@
 package com.guardians.application.user;
 
-import com.guardians.config.AwsS3Properties;
 import com.guardians.domain.user.entity.Role;
 import com.guardians.domain.user.entity.User;
+import com.guardians.domain.user.port.EmailVerificationPort;
 import com.guardians.domain.user.port.UserPort;
 import com.guardians.domain.user.service.UserDomainService;
 import com.guardians.dto.user.res.ResCreateUserDto;
 import com.guardians.dto.user.res.ResLoginDto;
 import com.guardians.exception.CustomException;
 import com.guardians.exception.ErrorCode;
-import com.guardians.service.auth.EmailVerificationService;
+import com.guardians.infrastructure.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @Service
@@ -26,8 +28,8 @@ public class UserFacade {
 
     private final UserPort userPort;
     private final PasswordEncoder passwordEncoder;
-    private final EmailVerificationService emailVerificationService;
-    private final AwsS3Properties awsS3Properties;
+    private final EmailVerificationPort emailVerificationPort;
+    private final S3Service s3Service;
     private final UserDomainService userDomainService;
 
     private User getUserWithStats(Long userId) {
@@ -46,7 +48,7 @@ public class UserFacade {
                 email,
                 encodedPw,
                 Role.USER,
-                awsS3Properties.getDefaultProfileUrl()
+                s3Service.getDefaultProfileUrl()
         );
 
         User saved = userPort.save(user);
@@ -107,7 +109,7 @@ public class UserFacade {
     public void verifyResetPassword(Long userId, String code, String newPassword) {
         User user = getUserWithStats(userId);
 
-        boolean verified = emailVerificationService.verifyCode(user.getEmail(), code);
+        boolean verified = emailVerificationPort.verifyCode(user.getEmail(), code);
         if (!verified) {
             throw new CustomException(ErrorCode.INVALID_PASSWORD);
         }
@@ -165,5 +167,19 @@ public class UserFacade {
     @Transactional
     public void updateProfileImageUrl(Long userId, String imageUrl) {
         getUserWithStats(userId).updateProfileImageUrl(imageUrl);
+    }
+
+    @Transactional
+    public String uploadProfileImage(Long userId, MultipartFile file) throws IOException {
+        String imageUrl = s3Service.uploadProfileImage(file);
+        getUserWithStats(userId).updateProfileImageUrl(imageUrl);
+        return imageUrl;
+    }
+
+    @Transactional
+    public String resetProfileImage(Long userId) {
+        String defaultUrl = s3Service.getDefaultProfileUrl();
+        getUserWithStats(userId).updateProfileImageUrl(defaultUrl);
+        return defaultUrl;
     }
 }

--- a/guardians/src/main/java/com/guardians/application/wargame/WargameFacade.java
+++ b/guardians/src/main/java/com/guardians/application/wargame/WargameFacade.java
@@ -1,5 +1,6 @@
 package com.guardians.application.wargame;
 
+import com.guardians.application.badge.BadgeFacade;
 import com.guardians.domain.user.entity.User;
 import com.guardians.domain.user.entity.UserStats;
 import com.guardians.domain.user.port.UserPort;
@@ -10,7 +11,6 @@ import com.guardians.domain.wargame.service.WargameDomainService;
 import com.guardians.dto.wargame.res.*;
 import com.guardians.exception.CustomException;
 import com.guardians.exception.ErrorCode;
-import io.fabric8.kubernetes.api.model.Pod;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -26,6 +26,8 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class WargameFacade {
 
+    private static final String WARGAME_NAMESPACE = "ns-wargame";
+
     private final WargamePort wargamePort;
     private final WargameFlagPort wargameFlagPort;
     private final SolvedWargamePort solvedWargamePort;
@@ -37,7 +39,9 @@ public class WargameFacade {
     private final UserPort userPort;
     private final UserStatsPort userStatsPort;
     private final WargameDomainService wargameDomainService;
-    private final com.guardians.application.badge.BadgeFacade badgeFacade;
+    // 타협: 배지 로직을 WargameFacade에 중복하는 것보다 BadgeFacade 의존이 낫다.
+    // 개선 방향: 도메인 이벤트(FlagSubmittedEvent) 도입 시 제거 가능
+    private final BadgeFacade badgeFacade;
 
     @Transactional
     public ResWargameListDto createWargame(String title, String description, Difficulty difficulty, int score,
@@ -102,7 +106,6 @@ public class WargameFacade {
             likedIds = new HashSet<>();
         }
 
-        // flag N+1 방지
         List<WargameFlag> flags = wargameFlagPort.findAllByWargameIdIn(wargameIds);
         Map<Long, String> flagMap = flags.stream()
                 .collect(Collectors.toMap(f -> f.getWargame().getId(), WargameFlag::getFlag));
@@ -252,16 +255,16 @@ public class WargameFacade {
 
     public List<ResHotWargameDto> getHotWargames() {
         Pageable top10 = PageRequest.of(0, 10);
-        return wargamePort.findHotWargames(top10).getContent();
+        return wargamePort.findHotWargames(top10).getContent().stream()
+                .map(r -> new ResHotWargameDto(r.getWargameId(), r.getTitle(), r.getSolveCount()))
+                .collect(Collectors.toList());
     }
 
     public List<ResUserStatusDto> getActiveUsersByWargame(Long wargameId) {
-        String namespace = "ns-wargame";
-        List<Pod> pods = kubernetesPodPort.getRunningPodsByWargameId(wargameId, namespace);
+        List<RunningPodInfo> pods = kubernetesPodPort.getRunningPodsByWargameId(wargameId, WARGAME_NAMESPACE);
 
         return pods.stream().map(pod -> {
-            String podName = pod.getMetadata().getName();
-            String[] parts = podName.split("-");
+            String[] parts = pod.podName().split("-");
 
             Long podUserId;
             try {
@@ -273,11 +276,7 @@ public class WargameFacade {
             User user = userPort.findById(podUserId).orElse(null);
             if (user == null) return null;
 
-            return new ResUserStatusDto(
-                    user.getUsername(),
-                    pod.getMetadata().getCreationTimestamp(),
-                    false
-            );
+            return new ResUserStatusDto(user.getUsername(), pod.creationTimestamp(), false);
         }).filter(Objects::nonNull).toList();
     }
 
@@ -285,5 +284,44 @@ public class WargameFacade {
         WargameFlag wargameFlag = wargameFlagPort.findByWargameId(wargameId)
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_PASSWORD));
         return wargameFlag.getFlag();
+    }
+
+    @Transactional
+    public Map<String, String> startWargamePod(Long userId, Long wargameId) {
+        String podName = "wargame-" + userId + "-" + wargameId;
+        kubernetesPodPort.createWargamePod(podName, wargameId, userId, WARGAME_NAMESPACE);
+        String url = String.format("https://%d-%d.wargames.bee-guardians.com", wargameId, userId);
+        return Map.of("podName", podName, "url", url);
+    }
+
+    @Transactional
+    public Map<String, Object> stopWargamePod(Long userId, Long wargameId) {
+        String podName = "wargame-" + userId + "-" + wargameId;
+        boolean deleted = kubernetesPodPort.deleteWargamePod(podName, WARGAME_NAMESPACE);
+        if (deleted) {
+            return Map.of("podName", podName, "url", kubernetesPodPort.generateIngressUrl(podName));
+        } else {
+            return Map.of("podName", podName);
+        }
+    }
+
+    public PodStatus getWargamePodStatus(Long userId, Long wargameId) {
+        String podName = "wargame-" + userId + "-" + wargameId;
+        return kubernetesPodPort.getPodStatus(podName, WARGAME_NAMESPACE);
+    }
+
+    @Transactional
+    public String startKaliPod(Long userId) {
+        kubernetesPodPort.createKaliPod(userId, WARGAME_NAMESPACE);
+        return String.format("https://kali-%d.wargames.bee-guardians.com", userId);
+    }
+
+    @Transactional
+    public boolean stopKaliPod(Long userId) {
+        return kubernetesPodPort.deleteKaliPod(userId, WARGAME_NAMESPACE);
+    }
+
+    public PodStatus getKaliPodStatus(Long userId) {
+        return kubernetesPodPort.getKaliPodStatus(userId, WARGAME_NAMESPACE);
     }
 }

--- a/guardians/src/main/java/com/guardians/controller/JobController.java
+++ b/guardians/src/main/java/com/guardians/controller/JobController.java
@@ -1,15 +1,11 @@
 package com.guardians.controller;
 
 import com.guardians.application.job.JobFacade;
-import com.guardians.domain.user.entity.User;
-import com.guardians.domain.user.port.UserPort;
 import com.guardians.dto.common.ResWrapper;
 import com.guardians.dto.job.req.ReqCreateJobDto;
 import com.guardians.dto.job.req.ReqUpdateJobDto;
 import com.guardians.dto.job.res.ResJobDto;
 import com.guardians.dto.job.res.ResJobListDto;
-import com.guardians.exception.CustomException;
-import com.guardians.exception.ErrorCode;
 import com.guardians.util.SessionUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -28,21 +24,19 @@ import java.util.List;
 public class JobController {
 
     private final JobFacade jobFacade;
-    private final UserPort userPort;
 
-    // 채용공고 등록
     @Operation(summary = "채용공고 등록", description = "관리자만 채용공고를 등록할 수 있습니다.")
     @PostMapping
     public ResponseEntity<ResWrapper<?>> createJob(
             @RequestBody @Valid ReqCreateJobDto dto,
             HttpSession session
     ) {
-        checkAdminWithDb(session);
+        Long userId = SessionUtil.getRequiredUserId(session);
+        jobFacade.verifyAdmin(userId);
         jobFacade.createJob(dto.getCompanyName(), dto.getTitle(), dto.getDescription(), dto.getLocation(), dto.getEmploymentType(), dto.getCareerLevel(), dto.getSalary(), dto.getDeadline(), dto.getSourceUrl());
         return ResponseEntity.ok(ResWrapper.resSuccess("[관리자] 채용공고 등록 완료", null));
     }
 
-    // 채용공고 수정
     @Operation(summary = "채용공고 수정", description = "관리자만 채용공고를 수정할 수 있습니다.")
     @PatchMapping("/{jobId}")
     public ResponseEntity<ResWrapper<?>> updateJob(
@@ -50,24 +44,24 @@ public class JobController {
             @RequestBody @Valid ReqUpdateJobDto dto,
             HttpSession session
     ) {
-        checkAdminWithDb(session);
+        Long userId = SessionUtil.getRequiredUserId(session);
+        jobFacade.verifyAdmin(userId);
         jobFacade.updateJob(jobId, dto.getTitle(), dto.getDescription(), dto.getSalary(), dto.getDeadline(), dto.getIsActive());
         return ResponseEntity.ok(ResWrapper.resSuccess("[관리자] 채용공고 수정 완료", null));
     }
 
-    // 채용공고 삭제
     @Operation(summary = "채용공고 삭제", description = "관리자만 채용공고를 삭제할 수 있습니다.")
     @DeleteMapping("/{jobId}")
     public ResponseEntity<ResWrapper<?>> deleteJob(
             @PathVariable Long jobId,
             HttpSession session
     ) {
-        checkAdminWithDb(session);
+        Long userId = SessionUtil.getRequiredUserId(session);
+        jobFacade.verifyAdmin(userId);
         jobFacade.deleteJob(jobId);
         return ResponseEntity.ok(ResWrapper.resSuccess("[관리자] 채용공고 삭제 완료", null));
     }
 
-    // 채용공고 목록 조회 (전체 공개)
     @Operation(summary = "채용공고 목록 조회", description = "모든 공개 채용공고를 최신순으로 조회합니다.")
     @GetMapping
     public ResponseEntity<ResWrapper<?>> getJobList() {
@@ -75,26 +69,10 @@ public class JobController {
         return ResponseEntity.ok(ResWrapper.resList("채용공고 목록 조회 성공", result, result.size()));
     }
 
-    // 채용공고 상세 조회 (전체 공개)
     @Operation(summary = "채용공고 상세 조회", description = "특정 채용공고의 상세 정보를 조회합니다.")
     @GetMapping("/{jobId}")
     public ResponseEntity<ResWrapper<?>> getJobDetail(@PathVariable Long jobId) {
         ResJobDto result = jobFacade.getJobDetail(jobId);
         return ResponseEntity.ok(ResWrapper.resSuccess("채용공고 상세 조회 성공", result));
-    }
-
-    /**
-     * DB에서 실제 사용자 role을 조회하여 관리자 권한을 검증합니다.
-     * 세션의 role 값만 믿지 않고 DB에서 확인하여 보안을 강화합니다.
-     */
-    private void checkAdminWithDb(HttpSession session) {
-        Long userId = SessionUtil.getRequiredUserId(session);
-
-        User user = userPort.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        if (!user.isAdmin()) {
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
-        }
     }
 }

--- a/guardians/src/main/java/com/guardians/controller/UserController.java
+++ b/guardians/src/main/java/com/guardians/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.guardians.controller;
 
+import com.guardians.application.auth.AuthFacade;
+import com.guardians.application.user.UserFacade;
 import com.guardians.domain.user.entity.Role;
 import com.guardians.dto.common.ResWrapper;
 import com.guardians.dto.user.req.*;
@@ -7,9 +9,6 @@ import com.guardians.dto.user.res.ResCreateUserDto;
 import com.guardians.dto.user.res.ResLoginDto;
 import com.guardians.exception.CustomException;
 import com.guardians.exception.ErrorCode;
-import com.guardians.application.user.UserFacade;
-import com.guardians.service.auth.EmailVerificationService;
-import com.guardians.infrastructure.s3.S3Service;
 import com.guardians.util.SessionUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -33,10 +32,8 @@ import java.util.List;
 public class UserController {
 
     private final UserFacade userFacade;
-    private final EmailVerificationService emailVerificationService;
-    private final S3Service s3Service;
+    private final AuthFacade authFacade;
 
-    // 회원가입
     @Operation(summary = "회원가입", description = "유저 정보를 받아 회원가입 처리")
     @PostMapping
     public ResponseEntity<ResWrapper<?>> createUser(@RequestBody @Valid ReqCreateUserDto requestDto) {
@@ -44,15 +41,13 @@ public class UserController {
         return ResponseEntity.ok(ResWrapper.resSuccess("회원가입 성공", createdUser));
     }
 
-    // 이메일 인증 코드 전송
     @Operation(summary = "이메일 인증코드 전송", description = "입력한 이메일로 인증코드 발송")
     @GetMapping("/send-code")
     public ResponseEntity<ResWrapper<?>> sendSignupCode(@RequestParam("email") String email) {
-        emailVerificationService.sendVerificationCode(email, "mail/signup-verification.html");
+        authFacade.sendVerificationCode(email, "mail/signup-verification.html");
         return ResponseEntity.ok(ResWrapper.resSuccess("회원가입 인증 메일 전송 완료", null));
     }
 
-    // 이메일 중복 체크
     @Operation(summary = "이메일 중복 확인", description = "이미 가입된 이메일인지 확인")
     @GetMapping("/check-email")
     public ResponseEntity<ResWrapper<?>> checkEmailExists(@RequestParam("email") String email) {
@@ -60,18 +55,16 @@ public class UserController {
         return ResponseEntity.ok(ResWrapper.resSuccess("이메일 존재 여부", exists));
     }
 
-    // 이메일 인증 코드 확인
     @Operation(summary = "이메일 인증코드 검증", description = "입력한 코드가 유효한지 확인")
     @PostMapping("/verify-code")
     public ResponseEntity<ResWrapper<?>> verifyCode(
             @RequestParam("email") String email,
             @RequestParam("code") String code
     ) {
-        boolean isValid = emailVerificationService.verifyCode(email, code);
+        boolean isValid = authFacade.verifyCode(email, code);
         return ResponseEntity.ok(ResWrapper.resSuccess("인증 결과", isValid));
     }
 
-    // 로그인 여부 확인
     @Operation(summary = "로그인 여부 확인", description = "현재 세션에 유저 정보가 존재하는지 확인합니다.")
     @GetMapping("/check")
     public ResponseEntity<?> checkLogin(HttpServletRequest request) {
@@ -92,7 +85,6 @@ public class UserController {
         return ResponseEntity.ok(ResWrapper.resSuccess("로그인 성공", loginUser));
     }
 
-    // ADMIN login
     @PostMapping("/admin/login")
     public ResponseEntity<ResWrapper<?>> adminLogin(
             @RequestBody @Valid ReqLoginDto loginDto,
@@ -110,7 +102,6 @@ public class UserController {
         return ResponseEntity.ok(ResWrapper.resSuccess("[관리자] 로그인 성공", loginUser));
     }
 
-
     @PutMapping("/admin/update-role/{userId}")
     public ResponseEntity<ResWrapper<?>> updateUserRole(
             @PathVariable Long userId,
@@ -124,7 +115,6 @@ public class UserController {
         return ResponseEntity.ok(ResWrapper.resSuccess("[관리자] 권한 변경 완료", null));
     }
 
-    // 모든 유저 조회
     @Operation(summary = "전체 유저 목록 조회", description = "관리자만 전체 유저 목록을 확인할 수 있습니다.")
     @GetMapping("/admin/list")
     public ResponseEntity<ResWrapper<?>> getAllUsers(HttpSession session) {
@@ -150,7 +140,6 @@ public class UserController {
         return ResponseEntity.ok(ResWrapper.resSuccess("로그아웃 완료 (세션 + 쿠키 삭제)", null));
     }
 
-    // 유저정보 - 닉네임 수정
     @PatchMapping("/{userId}/update")
     public ResponseEntity<ResWrapper<?>> updateUserInfo(
             @PathVariable("userId") Long userId,
@@ -164,7 +153,6 @@ public class UserController {
         return ResponseEntity.ok(ResWrapper.resSuccess("회원 정보 수정 완료", updatedUser));
     }
 
-    // 프로필 이미지 업로드
     @Operation(summary = "프로필 이미지 업로드", description = "S3에 프로필 이미지를 업로드하고 URL을 저장")
     @PostMapping("/{userId}/profile-image")
     public ResponseEntity<ResWrapper<?>> uploadProfileImage(
@@ -173,14 +161,10 @@ public class UserController {
             HttpSession session
     ) throws IOException {
         SessionUtil.requireSameUser(session, userId);
-
-        String imageUrl = s3Service.uploadProfileImage(file);
-        userFacade.updateProfileImageUrl(userId, imageUrl);
-
+        String imageUrl = userFacade.uploadProfileImage(userId, file);
         return ResponseEntity.ok(ResWrapper.resSuccess("프로필 이미지 업로드 성공", imageUrl));
     }
 
-    // 프로필 이미지 삭제 → 기본 이미지로 복구
     @Operation(summary = "프로필 이미지 삭제", description = "프로필 이미지를 기본 이미지로 롤백")
     @DeleteMapping("/{userId}/profile-image")
     public ResponseEntity<ResWrapper<?>> deleteProfileImage(
@@ -188,14 +172,10 @@ public class UserController {
             HttpSession session
     ) {
         SessionUtil.requireSameUser(session, userId);
-
-        String defaultUrl = s3Service.getDefaultProfileUrl();
-        userFacade.updateProfileImageUrl(userId, defaultUrl);
-
+        String defaultUrl = userFacade.resetProfileImage(userId);
         return ResponseEntity.ok(ResWrapper.resSuccess("프로필 이미지 기본으로 변경 완료", defaultUrl));
     }
 
-    // 비밀번호 변경
     @PatchMapping("/{userId}/reset-password")
     public ResponseEntity<ResWrapper<?>> changePassword(
             @PathVariable("userId") Long userId,
@@ -209,16 +189,14 @@ public class UserController {
         return ResponseEntity.ok(ResWrapper.resSuccess("비밀번호 변경 완료", null));
     }
 
-    // 비밀번호 찾기 - 이메일 인증 코드 전송
     @Operation(summary = "비밀번호 찾기 - 이메일 인증 코드 전송", description = "비밀번호 재설정을 위한 이메일 인증 코드 발송")
     @GetMapping("/{userId}/reset-password/send-code")
     public ResponseEntity<ResWrapper<?>> sendResetPasswordCode(@PathVariable Long userId) {
         String email = userFacade.getEmailByUserId(userId);
-        emailVerificationService.sendVerificationCode(email, "mail/password-reset.html");
+        authFacade.sendVerificationCode(email, "mail/password-reset.html");
         return ResponseEntity.ok(ResWrapper.resSuccess("비밀번호 재설정 코드 발송 완료", null));
     }
 
-    // 비밀번호 찾기 - 이메일 검증 / 재설정
     @Operation(summary = "비밀번호 찾기 - 비밀번호 재설정", description = "인증 코드 검증 후 새로운 비밀번호 설정")
     @PostMapping("/{userId}/reset-password/verify-code")
     public ResponseEntity<ResWrapper<?>> verifyResetPassword(
@@ -230,7 +208,6 @@ public class UserController {
         return ResponseEntity.ok(ResWrapper.resSuccess("비밀번호 재설정 완료", null));
     }
 
-    // 비밀번호 찾기 - 유저ID 가져오기
     @Operation(summary = "이메일로 유저 ID 조회", description = "입력된 이메일로 등록된 유저 ID를 반환")
     @GetMapping("/find-id")
     public ResponseEntity<ResWrapper<?>> findUserIdByEmail(@RequestParam String email) {
@@ -238,8 +215,6 @@ public class UserController {
         return ResponseEntity.ok(ResWrapper.resSuccess("유저 ID 반환", userId));
     }
 
-
-    // 회원 탈퇴
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴 처리")
     @DeleteMapping("/{userId}")
     public ResponseEntity<ResWrapper<?>> deleteUser(
@@ -254,7 +229,6 @@ public class UserController {
         return ResponseEntity.ok(ResWrapper.resSuccess("회원 탈퇴 완료", null));
     }
 
-    // 관리자 회원 삭제
     @Operation(summary = "관리자 전용 회원 삭제", description = "관리자가 특정 회원을 강제 탈퇴시킵니다.")
     @DeleteMapping("/admin/delete/{userId}")
     public ResponseEntity<ResWrapper<?>> adminDeleteUser(
@@ -267,13 +241,10 @@ public class UserController {
         return ResponseEntity.ok(ResWrapper.resSuccess("[관리자] 회원 삭제 완료", null));
     }
 
-
-    // UserId 정보 반환
     @GetMapping("/me")
     public ResponseEntity<ResWrapper<?>> getCurrentUser(HttpSession session) {
         Long userId = SessionUtil.getRequiredUserId(session);
         ResLoginDto user = userFacade.getUserInfo(userId);
         return ResponseEntity.ok(ResWrapper.resSuccess("유저 정보 조회 성공", user));
     }
-
 }

--- a/guardians/src/main/java/com/guardians/controller/WargameController.java
+++ b/guardians/src/main/java/com/guardians/controller/WargameController.java
@@ -1,7 +1,7 @@
 package com.guardians.controller;
 
 import com.guardians.application.wargame.WargameFacade;
-import com.guardians.domain.wargame.port.KubernetesPodPort;
+import com.guardians.domain.wargame.port.PodStatus;
 import com.guardians.dto.common.ResWrapper;
 import com.guardians.dto.wargame.req.ReqCreateReviewDto;
 import com.guardians.dto.wargame.req.ReqCreateWargameDto;
@@ -16,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -28,7 +27,6 @@ import java.util.Optional;
 public class WargameController {
 
     private final WargameFacade wargameFacade;
-    private final KubernetesPodPort kubernetesPodPort;
 
     @PostMapping("/admin")
     public ResponseEntity<ResWrapper<?>> createWargame(
@@ -50,7 +48,6 @@ public class WargameController {
         return ResponseEntity.ok(ResWrapper.resSuccess("워게임 삭제 완료", null));
     }
 
-
     @GetMapping
     public ResponseEntity<ResWrapper<?>> getWargameList(HttpServletRequest request) {
         HttpSession session = request.getSession(false);
@@ -69,7 +66,6 @@ public class WargameController {
         ResWargameListDto result = wargameFacade.getWargameById(userId, wargameId);
         return ResponseEntity.ok(ResWrapper.resSuccess("워게임 상세 조회 성공", result));
     }
-
 
     @PostMapping("/{wargameId}/submit")
     public ResponseEntity<ResWrapper<?>> submitFlag(
@@ -142,27 +138,14 @@ public class WargameController {
         return ResponseEntity.ok(ResWrapper.resSuccess("리뷰 삭제 성공", null));
     }
 
-
     @PostMapping("/{wargameId}/start")
     public ResponseEntity<ResWrapper<?>> startWargamePod(
             @PathVariable Long wargameId,
             HttpSession session
     ) {
         Long userId = SessionUtil.getRequiredUserId(session);
-
-        String podName = "wargame-" + userId + "-" + wargameId;
-        String namespace = "ns-wargame";
-
-        kubernetesPodPort.createWargamePod(podName, wargameId, userId, namespace);
-
-        String url = String.format("https://%d-%d.wargames.bee-guardians.com", wargameId, userId);
-
-        return ResponseEntity.ok(
-                ResWrapper.resSuccess("워게임 인스턴스 시작됨", Map.of(
-                        "podName", podName,
-                        "url", url
-                ))
-        );
+        Map<String, String> result = wargameFacade.startWargamePod(userId, wargameId);
+        return ResponseEntity.ok(ResWrapper.resSuccess("워게임 인스턴스 시작됨", result));
     }
 
     @DeleteMapping("/{wargameId}/stop")
@@ -171,25 +154,10 @@ public class WargameController {
             HttpSession session
     ) {
         Long userId = SessionUtil.getRequiredUserId(session);
-
-        String podName = "wargame-" + userId + "-" + wargameId;
-        String namespace = "ns-wargame";
-
-        boolean deleted = kubernetesPodPort.deleteWargamePod(podName, namespace);
-        if (deleted) {
-            return ResponseEntity.ok(
-                    ResWrapper.resSuccess("워게임 인스턴스 종료됨", Map.of(
-                            "podName", podName,
-                            "url", kubernetesPodPort.generateIngressUrl(podName)
-                    ))
-            );
-        } else {
-            return ResponseEntity.ok(
-                    ResWrapper.resSuccess("종료할 워게임 인스턴스를 찾을 수 없음", Map.of(
-                            "podName", podName
-                    ))
-            );
-        }
+        Map<String, Object> result = wargameFacade.stopWargamePod(userId, wargameId);
+        boolean deleted = result.containsKey("url");
+        String message = deleted ? "워게임 인스턴스 종료됨" : "종료할 워게임 인스턴스를 찾을 수 없음";
+        return ResponseEntity.ok(ResWrapper.resSuccess(message, result));
     }
 
     @GetMapping("/{wargameId}/status")
@@ -198,17 +166,9 @@ public class WargameController {
             HttpSession session
     ) {
         Long userId = SessionUtil.getRequiredUserId(session);
-
-        String podName = "wargame-" + userId + "-" + wargameId;
-        String namespace = "ns-wargame";
-
-        PodStatusDto podStatus = kubernetesPodPort.getPodStatus(podName, namespace);
-
-        Map<String, Object> result = new HashMap<>();
-        result.put("status", podStatus.getStatus());
-        result.put("url", podStatus.getUrl());
-
-        return ResponseEntity.ok(ResWrapper.resSuccess("Pod 상태 조회 성공", result));
+        PodStatus podStatus = wargameFacade.getWargamePodStatus(userId, wargameId);
+        return ResponseEntity.ok(ResWrapper.resSuccess("Pod 상태 조회 성공",
+                Map.of("status", podStatus.status(), "url", Optional.ofNullable(podStatus.url()).orElse(""))));
     }
 
     @GetMapping("/hot")
@@ -228,41 +188,25 @@ public class WargameController {
     @PostMapping("/kali/start")
     public ResponseEntity<ResWrapper<?>> startKaliPod(HttpSession session) {
         Long userId = SessionUtil.getRequiredUserId(session);
-
-        String namespace = "ns-wargame";
-        kubernetesPodPort.createKaliPod(userId, namespace);
-
-        String url = String.format("https://kali-%d.wargames.bee-guardians.com", userId);
-        return ResponseEntity.ok(
-                ResWrapper.resSuccess("Kali 인스턴스 시작됨", Map.of(
-                        "url", url
-                ))
-        );
+        String url = wargameFacade.startKaliPod(userId);
+        return ResponseEntity.ok(ResWrapper.resSuccess("Kali 인스턴스 시작됨", Map.of("url", url)));
     }
 
     @DeleteMapping("/kali/stop")
     public ResponseEntity<ResWrapper<?>> stopKaliPod(HttpSession session) {
         Long userId = SessionUtil.getRequiredUserId(session);
-
-        String namespace = "ns-wargame";
-        boolean deleted = kubernetesPodPort.deleteKaliPod(userId, namespace);
-        return ResponseEntity.ok(
-                ResWrapper.resSuccess(deleted ? "Kali 인스턴스 종료됨" : "Kali 인스턴스 삭제 실패", null)
-        );
+        boolean deleted = wargameFacade.stopKaliPod(userId);
+        return ResponseEntity.ok(ResWrapper.resSuccess(deleted ? "Kali 인스턴스 종료됨" : "Kali 인스턴스 삭제 실패", null));
     }
 
     @GetMapping("/kali/status")
     public ResponseEntity<ResWrapper<?>> getKaliPodStatus(HttpSession session) {
         Long userId = SessionUtil.getRequiredUserId(session);
-
-        String namespace = "ns-wargame";
-        PodStatusDto status = kubernetesPodPort.getKaliPodStatus(userId, namespace);
-        return ResponseEntity.ok(
-                ResWrapper.resSuccess("Kali 상태 조회 성공", Map.of(
-                        "status", Optional.ofNullable(status.getStatus()).orElse("UNKNOWN"),
-                        "url", Optional.ofNullable(status.getUrl()).orElse("")
-                ))
-        );
+        PodStatus status = wargameFacade.getKaliPodStatus(userId);
+        return ResponseEntity.ok(ResWrapper.resSuccess("Kali 상태 조회 성공", Map.of(
+                "status", Optional.ofNullable(status.status()).orElse("UNKNOWN"),
+                "url", Optional.ofNullable(status.url()).orElse("")
+        )));
     }
 
     @GetMapping("/admin/{wargameId}/flag")
@@ -271,10 +215,7 @@ public class WargameController {
             HttpSession session
     ) {
         SessionUtil.requireAdmin(session);
-
         String flag = wargameFacade.getWargameFlag(wargameId);
-
         return ResponseEntity.ok(ResWrapper.resSuccess("워게임 플래그 조회 성공", Map.of("flag", flag)));
     }
-
 }

--- a/guardians/src/main/java/com/guardians/domain/job/entity/Job.java
+++ b/guardians/src/main/java/com/guardians/domain/job/entity/Job.java
@@ -6,7 +6,6 @@ import lombok.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-@Setter
 @Builder
 @AllArgsConstructor
 @Entity

--- a/guardians/src/main/java/com/guardians/domain/user/port/EmailVerificationPort.java
+++ b/guardians/src/main/java/com/guardians/domain/user/port/EmailVerificationPort.java
@@ -1,0 +1,6 @@
+package com.guardians.domain.user.port;
+
+public interface EmailVerificationPort {
+    void sendVerificationCode(String email, String templatePath);
+    boolean verifyCode(String email, String code);
+}

--- a/guardians/src/main/java/com/guardians/domain/wargame/port/HotWargameResult.java
+++ b/guardians/src/main/java/com/guardians/domain/wargame/port/HotWargameResult.java
@@ -1,0 +1,12 @@
+package com.guardians.domain.wargame.port;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class HotWargameResult {
+    private final Long wargameId;
+    private final String title;
+    private final Long solveCount;
+}

--- a/guardians/src/main/java/com/guardians/domain/wargame/port/KubernetesPodPort.java
+++ b/guardians/src/main/java/com/guardians/domain/wargame/port/KubernetesPodPort.java
@@ -1,17 +1,14 @@
 package com.guardians.domain.wargame.port;
 
-import com.guardians.dto.wargame.res.PodStatusDto;
-import io.fabric8.kubernetes.api.model.Pod;
-
 import java.util.List;
 
 public interface KubernetesPodPort {
     void createWargamePod(String podName, Long wargameId, Long userId, String namespace);
     boolean deleteWargamePod(String podName, String namespace);
-    PodStatusDto getPodStatus(String podName, String namespace);
-    List<Pod> getRunningPodsByWargameId(Long wargameId, String namespace);
+    PodStatus getPodStatus(String podName, String namespace);
+    List<RunningPodInfo> getRunningPodsByWargameId(Long wargameId, String namespace);
     String generateIngressUrl(String podName);
     void createKaliPod(Long userId, String namespace);
     boolean deleteKaliPod(Long userId, String namespace);
-    PodStatusDto getKaliPodStatus(Long userId, String namespace);
+    PodStatus getKaliPodStatus(Long userId, String namespace);
 }

--- a/guardians/src/main/java/com/guardians/domain/wargame/port/PodStatus.java
+++ b/guardians/src/main/java/com/guardians/domain/wargame/port/PodStatus.java
@@ -1,0 +1,4 @@
+package com.guardians.domain.wargame.port;
+
+public record PodStatus(String status, String url) {
+}

--- a/guardians/src/main/java/com/guardians/domain/wargame/port/RunningPodInfo.java
+++ b/guardians/src/main/java/com/guardians/domain/wargame/port/RunningPodInfo.java
@@ -1,0 +1,4 @@
+package com.guardians.domain.wargame.port;
+
+public record RunningPodInfo(String podName, String creationTimestamp) {
+}

--- a/guardians/src/main/java/com/guardians/domain/wargame/port/WargamePort.java
+++ b/guardians/src/main/java/com/guardians/domain/wargame/port/WargamePort.java
@@ -1,7 +1,6 @@
 package com.guardians.domain.wargame.port;
 
 import com.guardians.domain.wargame.entity.Wargame;
-import com.guardians.dto.wargame.res.ResHotWargameDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -13,7 +12,7 @@ public interface WargamePort {
     Optional<Wargame> findById(Long id);
     Optional<Wargame> findByIdWithCategory(Long id);
     List<Wargame> findByCategoryName(String categoryName);
-    Page<ResHotWargameDto> findHotWargames(Pageable pageable);
+    Page<HotWargameResult> findHotWargames(Pageable pageable);
     Wargame save(Wargame wargame);
     void delete(Wargame wargame);
 }

--- a/guardians/src/main/java/com/guardians/infrastructure/kubernetes/KubernetesPodAdapter.java
+++ b/guardians/src/main/java/com/guardians/infrastructure/kubernetes/KubernetesPodAdapter.java
@@ -2,8 +2,9 @@ package com.guardians.infrastructure.kubernetes;
 
 import com.guardians.domain.wargame.entity.Wargame;
 import com.guardians.domain.wargame.port.KubernetesPodPort;
+import com.guardians.domain.wargame.port.PodStatus;
+import com.guardians.domain.wargame.port.RunningPodInfo;
 import com.guardians.domain.wargame.port.WargamePort;
-import com.guardians.dto.wargame.res.PodStatusDto;
 import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.networking.v1.*;
 import io.fabric8.kubernetes.client.Config;
@@ -145,29 +146,29 @@ public class KubernetesPodAdapter implements KubernetesPodPort {
     }
 
     @Override
-    public PodStatusDto getPodStatus(String podName, String namespace) {
+    public PodStatus getPodStatus(String podName, String namespace) {
         try (KubernetesClient client = getK8sClient()) {
             Pod pod = client.pods().inNamespace(namespace).withName(podName).get();
 
             if (pod == null) {
-                return new PodStatusDto("Not Found", null);
+                return new PodStatus("Not Found", null);
             }
 
             if (pod.getMetadata().getDeletionTimestamp() != null) {
-                return new PodStatusDto("Terminating", generateIngressUrl(podName));
+                return new PodStatus("Terminating", generateIngressUrl(podName));
             }
 
             String phase = pod.getStatus().getPhase();
             if ("Succeeded".equals(phase) || "Failed".equals(phase)) {
-                return new PodStatusDto("Not Found", null);
+                return new PodStatus("Not Found", null);
             }
 
-            return new PodStatusDto(phase, generateIngressUrl(podName));
+            return new PodStatus(phase, generateIngressUrl(podName));
         }
     }
 
     @Override
-    public List<Pod> getRunningPodsByWargameId(Long wargameId, String namespace) {
+    public List<RunningPodInfo> getRunningPodsByWargameId(Long wargameId, String namespace) {
         try (KubernetesClient client = getK8sClient()) {
             return client.pods()
                     .inNamespace(namespace)
@@ -179,6 +180,10 @@ public class KubernetesPodAdapter implements KubernetesPodPort {
                         String phase = pod.getStatus().getPhase();
                         return name.contains("-" + wargameId) && "Running".equals(phase);
                     })
+                    .map(pod -> new RunningPodInfo(
+                            pod.getMetadata().getName(),
+                            pod.getMetadata().getCreationTimestamp()
+                    ))
                     .collect(Collectors.toList());
         }
     }
@@ -296,25 +301,25 @@ public class KubernetesPodAdapter implements KubernetesPodPort {
     }
 
     @Override
-    public PodStatusDto getKaliPodStatus(Long userId, String namespace) {
+    public PodStatus getKaliPodStatus(Long userId, String namespace) {
         try (KubernetesClient client = getK8sClient()) {
             String podName = "kali-" + userId;
             Pod pod = client.pods().inNamespace(namespace).withName(podName).get();
 
             if (pod == null) {
-                return new PodStatusDto("Not Found", null);
+                return new PodStatus("Not Found", null);
             }
 
             if (pod.getMetadata().getDeletionTimestamp() != null) {
-                return new PodStatusDto("Terminating", getKaliIngressUrl(userId));
+                return new PodStatus("Terminating", getKaliIngressUrl(userId));
             }
 
             String phase = pod.getStatus().getPhase();
             if ("Succeeded".equals(phase) || "Failed".equals(phase)) {
-                return new PodStatusDto("Not Found", null);
+                return new PodStatus("Not Found", null);
             }
 
-            return new PodStatusDto(phase, getKaliIngressUrl(userId));
+            return new PodStatus(phase, getKaliIngressUrl(userId));
         }
     }
 

--- a/guardians/src/main/java/com/guardians/infrastructure/mail/EmailVerificationAdapter.java
+++ b/guardians/src/main/java/com/guardians/infrastructure/mail/EmailVerificationAdapter.java
@@ -1,0 +1,67 @@
+package com.guardians.infrastructure.mail;
+
+import com.guardians.domain.user.port.EmailVerificationPort;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationAdapter implements EmailVerificationPort {
+
+    private final JavaMailSender mailSender;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    @Async
+    public void sendVerificationCode(String email, String templatePath) {
+        String code = generateCode();
+        String htmlContent = loadTemplate(templatePath, code);
+
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(email);
+            helper.setSubject("Guardians 이메일 인증 코드");
+            helper.setText(htmlContent, true);
+
+            mailSender.send(message);
+            redisTemplate.opsForValue().set(email, code, 5, TimeUnit.MINUTES);
+
+        } catch (MessagingException e) {
+            System.err.println("이메일 전송 실패: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean verifyCode(String email, String code) {
+        String storedCode = redisTemplate.opsForValue().get(email);
+        return code.equals(storedCode);
+    }
+
+    private String generateCode() {
+        return String.valueOf(new Random().nextInt(900000) + 100000);
+    }
+
+    private String loadTemplate(String path, String code) {
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream(path)) {
+            if (is == null) throw new IllegalArgumentException("템플릿 파일 없음: " + path);
+            String html = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            return html.replace("%CODE%", code);
+        } catch (IOException e) {
+            throw new RuntimeException("템플릿 읽기 실패", e);
+        }
+    }
+}

--- a/guardians/src/main/java/com/guardians/infrastructure/persistence/wargame/JpaWargameRepository.java
+++ b/guardians/src/main/java/com/guardians/infrastructure/persistence/wargame/JpaWargameRepository.java
@@ -1,7 +1,7 @@
 package com.guardians.infrastructure.persistence.wargame;
 
 import com.guardians.domain.wargame.entity.Wargame;
-import com.guardians.dto.wargame.res.ResHotWargameDto;
+import com.guardians.domain.wargame.port.HotWargameResult;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,7 +14,7 @@ import java.util.Optional;
 interface JpaWargameRepository extends JpaRepository<Wargame, Long> {
 
     @Query("""
-        SELECT new com.guardians.dto.wargame.res.ResHotWargameDto(
+        SELECT new com.guardians.domain.wargame.port.HotWargameResult(
             w.id,
             w.title,
             COUNT(sw)
@@ -24,7 +24,7 @@ interface JpaWargameRepository extends JpaRepository<Wargame, Long> {
         GROUP BY w.id, w.title
         ORDER BY COUNT(sw) DESC
     """)
-    Page<ResHotWargameDto> findHotWargames(Pageable pageable);
+    Page<HotWargameResult> findHotWargames(Pageable pageable);
 
     @Query("SELECT w FROM Wargame w JOIN FETCH w.category")
     List<Wargame> findAllWithCategory();

--- a/guardians/src/main/java/com/guardians/infrastructure/persistence/wargame/WargameAdapter.java
+++ b/guardians/src/main/java/com/guardians/infrastructure/persistence/wargame/WargameAdapter.java
@@ -1,8 +1,8 @@
 package com.guardians.infrastructure.persistence.wargame;
 
 import com.guardians.domain.wargame.entity.Wargame;
+import com.guardians.domain.wargame.port.HotWargameResult;
 import com.guardians.domain.wargame.port.WargamePort;
-import com.guardians.dto.wargame.res.ResHotWargameDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -38,7 +38,7 @@ public class WargameAdapter implements WargamePort {
     }
 
     @Override
-    public Page<ResHotWargameDto> findHotWargames(Pageable pageable) {
+    public Page<HotWargameResult> findHotWargames(Pageable pageable) {
         return jpa.findHotWargames(pageable);
     }
 


### PR DESCRIPTION
## Background

DDD 헥사고날 아키텍처로 리팩토링(PR #68) 이후에도 여러 레이어 위반이 남아 있었습니다. Controller가 Port나 인프라 서비스를 직접 주입받거나, Port 인터페이스가 DTO·외부 라이브러리 타입을 노출하거나, Facade가 인프라 설정 빈에 직접 의존하는 문제들이 DIP 원칙과 헥사고날 경계를 훼손하고 있었습니다.

## Summary

실용적 타협 원칙 하에 전체 위반 목록을 일괄 수정했습니다. 과도한 복잡도를 유발하는 항목은 타협 처리했으며, 도메인 객체 도입·Port 분리·의존 재배치를 통해 레이어 경계를 정리했습니다.

## Changes

Port DTO 누수를 도메인 값 객체로 교체했습니다. `WargamePort.findHotWargames`가 반환하던 `ResHotWargameDto` 대신 `HotWargameResult`를, `KubernetesPodPort`에서 노출하던 `PodStatusDto`와 `List<Pod>` 대신 `PodStatus`·`RunningPodInfo` 레코드를 도입해 Port가 외부 타입에 의존하지 않도록 했습니다.

Controller의 직접 의존을 Facade로 이동했습니다. `WargameController`에서 `KubernetesPodPort`를 직접 주입하던 Pod 생명주기 메서드들을 `WargameFacade`로 옮기고, `JobController`의 DB 기반 관리자 검증 로직을 `JobFacade.verifyAdmin`으로 분리했습니다. `UserController`에서 `S3Service`와 `EmailVerificationService`를 직접 호출하던 부분도 각각 `UserFacade`와 `AuthFacade`로 위임했습니다.

이메일 인증을 Port/Adapter 구조로 분리했습니다. `service/auth/EmailVerificationService`를 `EmailVerificationPort` 인터페이스와 `EmailVerificationAdapter`로 분리하여 domain layer가 인프라에 직접 의존하지 않도록 했습니다. `UserFacade`와 `AuthFacade` 모두 포트를 통해 주입받습니다.

`UserFacade`의 인프라 의존을 정리했습니다. `AwsS3Properties`를 직접 주입받던 방식을 `S3Service.getDefaultProfileUrl()` 호출로 교체하고, 프로필 이미지 업로드·초기화 로직을 Facade 메서드로 통합했습니다.

`QnaFacade`의 트랜잭션 설정을 수정했습니다. 클래스 레벨 `@Transactional`을 `readOnly = true`로 바꾸고 쓰기 메서드에만 `@Transactional`을 추가해 읽기 메서드가 불필요한 쓰기 트랜잭션을 사용하지 않도록 했습니다.

`Job` 엔티티의 클래스 레벨 `@Setter`를 제거했습니다. 이미 `update()` 메서드가 있으므로 외부에서 필드를 임의 수정하는 경로를 차단했습니다.

**타협 항목** (적용하지 않은 수정): `WargameFacade → BadgeFacade` 크로스 도메인 의존은 배지 로직 중복이 더 나쁘다고 판단해 유지했습니다(도메인 이벤트 패턴 도입 시 해소 가능). Anemic 엔티티(`Badge`, `Bookmark`, `WargameLike` 등)는 단순 연관 테이블이므로 인위적 메서드 추가를 강제하지 않았습니다. `HealthCheckController → HealthCheckService` 직접 참조도 어드민 전용 인프라 유틸리티이므로 Facade 래퍼 추가는 불필요한 보일러플레이트로 판단해 제외했습니다.

## Checklist

- [ ] 프로덕션 코드(`compileJava`) 컴파일 성공 확인
- [ ] Pod 생명주기 API (start/stop/status) 동작 확인
- [ ] 이메일 인증 코드 발송/검증 동작 확인
- [ ] 프로필 이미지 업로드/초기화 동작 확인
- [ ] 채용공고 관리자 권한 검증 동작 확인
